### PR TITLE
Farm info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7463,6 +7463,7 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-error",
  "tracing-subscriber 0.3.16",
+ "whoami",
 ]
 
 [[package]]
@@ -8993,6 +8994,17 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "whoami"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6631b6a2fd59b1841b622e8f1a7ad241ef0a46f2d580464ce8140ac94cbd571"
+dependencies = [
+ "bumpalo",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,22 +166,22 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "event-listener",
  "futures-core",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
- "concurrent-queue",
+ "concurrent-queue 2.0.0",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
@@ -208,7 +208,7 @@ checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue",
+ "concurrent-queue 1.2.4",
  "futures-lite",
  "libc",
  "log",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ca34107f97baef6cfb231b32f36115781856b8f8208e8c580e0bcaea374842"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 dependencies = [
  "jobserver",
 ]
@@ -880,6 +880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2587,12 +2596,13 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
+checksum = "4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19"
 dependencies = [
  "console",
  "number_prefix",
+ "portable-atomic",
  "unicode-width",
 ]
 
@@ -2966,9 +2976,9 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libp2p"
@@ -4776,6 +4786,12 @@ dependencies = [
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ bytesize-serde = "0.2.0"
 clap = { version = "4.0.18", features = ["derive"] }
 color-eyre = "0.6.2"
 dirs = "4.0.0"
+futures = "0.3.25"
+indicatif = "0.17.1"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 thiserror = "1.0.35"
@@ -20,8 +22,7 @@ tracing-appender = "0.2"
 tracing-bunyan-formatter = "0.3.4"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-indicatif = "0.17.1"
-futures = "0.3.25"
+whoami = "1.2.3"
 
 subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "ac669aee4c5d89514599c063a0fca033ad247c18" }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-08-12"
+channel = "nightly-2022-11-09"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -1,11 +1,17 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
 use color_eyre::eyre::{Report, Result};
+
 use futures::prelude::*;
 use indicatif::{ProgressBar, ProgressStyle};
-use subspace_sdk::Farmer;
-use subspace_sdk::{chain_spec, Node, PlotDescription, PublicKey};
 use tracing::instrument;
 
+use subspace_sdk::Farmer;
+use subspace_sdk::{chain_spec, Node, PlotDescription, PublicKey};
+
 use crate::config::parse_config;
+use crate::summary::{create_summary_file, update_summary};
 use crate::utils::{install_tracing, node_directory_getter};
 
 #[derive(Debug)]
@@ -24,13 +30,19 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<()> {
     let args = prepare_farming().await?;
     println!("Node started successfully!");
 
+    create_summary_file().await?;
+
     println!("Starting farmer ...");
     let (farmer, _node) = start_farming(args).await?;
     println!("Farmer started successfully!");
 
     if !is_verbose {
+        let is_initial_progress_finished = Arc::new(AtomicBool::new(false));
         let sector_size_bytes = farmer.get_info().await.map_err(Report::msg)?.sector_size;
         let farmer_clone = farmer.clone();
+        let finished_flag = is_initial_progress_finished.clone();
+
+        // initial plotting progress subscriber
         tokio::spawn(async move {
             for (plot_id, plot) in farmer_clone.iter_plots().await.enumerate() {
                 println!(
@@ -57,17 +69,30 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<()> {
                     .progress_chars("=> "),
                 );
                 progress_bar.finish_with_message("Initial plotting finished!");
+                finished_flag.store(true, Ordering::Relaxed);
+                if let Err(why) = update_summary(Some(true), None).await {
+                    println!("updating summary failed, because: {why}");
+                }
             }
         });
 
+        // solution subscriber
         tokio::spawn({
             let farmer_clone = farmer.clone();
+            // TODO: initialize this value from the file
+            let farmed_block_count = Arc::new(AtomicU64::new(0));
             async move {
                 for plot in farmer_clone.iter_plots().await {
                     plot.subscribe_new_solutions()
                         .await
-                        .for_each(|_solution| async move {
-                            println!("Farmed a new block!");
+                        .for_each(|_solution| async {
+                            let total_farmed = farmed_block_count.fetch_add(1, Ordering::Relaxed);
+                            if let Err(why) = update_summary(None, Some(total_farmed)).await {
+                                println!("updating summary failed, because: {why}");
+                            }
+                            if is_initial_progress_finished.load(Ordering::Relaxed) {
+                                println!("Farmed {total_farmed} block(s)!");
+                            }
                         })
                         .await
                 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,5 +1,6 @@
-use color_eyre::eyre::Result;
 use std::{fs::File, io::Write};
+
+use color_eyre::eyre::Result;
 
 use crate::config::{construct_config, create_config};
 use crate::utils::{

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,7 +9,6 @@ use crate::utils::{
 };
 
 const DEFAULT_PLOT_SIZE: &str = "100GB";
-const DEFAULT_NODE_NAME: &str = "NODE_NAME";
 const DEFAULT_CHAIN: &str = "gemini-2a";
 
 pub(crate) fn init() -> Result<()> {
@@ -42,9 +41,10 @@ fn fill_config_from_user_inputs(mut config: File) -> Result<()> {
         "Reward address is using an invalid format. Please enter a valid address.",
     )?;
 
+    let default_node_name = whoami::username();
     let node_name = get_user_input(
-        &format!("Enter your node name to be identified on the network(defaults to `{}`, press enter to use the default): ", DEFAULT_NODE_NAME),
-        Some(DEFAULT_NODE_NAME),
+        &format!("Enter your node name to be identified on the network(defaults to `{}`, press enter to use the default): ", default_node_name),
+        Some(&default_node_name),
         is_valid_node_name,
         "Node name cannot include non-ascii characters! Please enter a valid node name.")?;
 

--- a/src/commands/wipe.rs
+++ b/src/commands/wipe.rs
@@ -14,7 +14,7 @@ pub(crate) async fn wipe() -> Result<()> {
         }
     };
     let node_directory = node_directory_getter();
-    let _ = Node::wipe(node_directory).await;
+    Node::wipe(node_directory).await?;
     println!("Node is wiped!");
 
     // TODO: modify here when supporting multi-plot

--- a/src/commands/wipe.rs
+++ b/src/commands/wipe.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::Result;
+
 use subspace_sdk::{Node, PlotDescription};
 
 use crate::config::parse_config;
@@ -13,7 +14,7 @@ pub(crate) async fn wipe() -> Result<()> {
         }
     };
     let node_directory = node_directory_getter();
-    Node::wipe(node_directory).await?;
+    let _ = Node::wipe(node_directory).await;
     println!("Node is wiped!");
 
     // TODO: modify here when supporting multi-plot
@@ -21,9 +22,9 @@ pub(crate) async fn wipe() -> Result<()> {
         directory: config_args.farmer_config_args.plot.directory,
         space_pledged: config_args.farmer_config_args.plot.space_pledged,
     };
-    println!("Farmer is wiped!");
 
-    plot.wipe().await?;
+    let _ = plot.wipe().await;
+    println!("Farmer is wiped!");
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ pub(crate) fn create_config() -> Result<(File, PathBuf)> {
         .expect("couldn't get the default config directory!")
         .join("subspace-cli");
 
-    let _ = create_dir(config_path.clone()); // if folder already exists, ignore the error
+    let _ = create_dir(&config_path); // if folder already exists, ignore the error
 
     let file = File::create(config_path.join("settings.toml"))?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,16 +1,17 @@
-use bytesize::ByteSize;
-use color_eyre::eyre::{Report, Result};
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::{
     fs::{create_dir, File},
     path::PathBuf,
 };
-use subspace_sdk::{PlotDescription, PublicKey};
+
+use bytesize::ByteSize;
+use color_eyre::eyre::{Report, Result};
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
+use subspace_sdk::{PlotDescription, PublicKey};
+
 #[derive(Deserialize, Serialize)]
-#[allow(dead_code)]
 struct Config {
     farmer: FarmerConfig,
     node: NodeConfig,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod config;
+mod summary;
 mod utils;
 
 use clap::{Parser, Subcommand};

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,0 +1,90 @@
+/// Stores the summary of the farming process into a file.
+/// This allows to retrieve farming information with `info` command,
+/// and also store the amount of potentially farmed blocks during the initial plotting progress,
+/// so that progress bar won't be affected with `println!`, and user will still know about them
+/// when initial plotting is finished.
+use std::path::PathBuf;
+
+use color_eyre::eyre::{Report, Result};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    fs::{read_to_string, File, OpenOptions},
+    io::AsyncWriteExt,
+};
+use tracing::instrument;
+
+#[derive(Deserialize, Serialize, Debug)]
+struct FarmerSummary {
+    initial_plotting_finished: bool,
+    farmed_block_count: u64,
+}
+
+#[instrument]
+pub(crate) async fn create_summary_file() -> Result<()> {
+    let summary_path = summary_path();
+
+    // File::create will truncate the existing file, so first
+    // check if the file exists, if not, `open` will return an error
+    // in this case, create the file
+    // if creation gives an error, that means the directory is not created
+    if File::open(&summary_path).await.is_err() {
+        if File::create(&summary_path).await.is_err() {
+            return Err(Report::msg(
+                "Your config directory is malformed. Please re-run `subspace init`",
+            ));
+        } else {
+            let initialization = FarmerSummary {
+                initial_plotting_finished: false,
+                farmed_block_count: 0,
+            };
+            let summary = toml::to_string(&initialization).map_err(Report::msg)?;
+            OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(summary_path)
+                .await?
+                .write_all(summary.as_bytes())
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+#[instrument]
+pub(crate) async fn update_summary(
+    plotting_finished: Option<bool>,
+    farmed_block_count: Option<u64>,
+) -> Result<()> {
+    let summary_path = summary_path();
+    let mut summary = parse_summary(&summary_path).await?;
+    if let Some(flag) = plotting_finished {
+        summary.initial_plotting_finished = flag;
+    }
+    if let Some(count) = farmed_block_count {
+        summary.farmed_block_count = count;
+    }
+
+    let new_summary = toml::to_string(&summary).map_err(Report::msg)?;
+
+    OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(summary_path)
+        .await?
+        .write_all(new_summary.as_bytes())
+        .await?;
+
+    Ok(())
+}
+
+#[instrument]
+async fn parse_summary(path: &PathBuf) -> Result<FarmerSummary> {
+    let summary: FarmerSummary = toml::from_str(&read_to_string(path).await?)?;
+    Ok(summary)
+}
+
+#[instrument]
+fn summary_path() -> PathBuf {
+    let summary_path = dirs::config_dir().expect("couldn't get the default config directory!");
+    summary_path.join("subspace-cli").join("summary.toml")
+}

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -77,6 +77,11 @@ pub(crate) async fn update_summary(
     Ok(())
 }
 
+pub(crate) async fn get_farmed_block_count() -> Result<u64> {
+    let summary = parse_summary(&summary_path()).await?;
+    Ok(summary.farmed_block_count)
+}
+
 #[instrument]
 async fn parse_summary(path: &PathBuf) -> Result<FarmerSummary> {
     let summary: FarmerSummary = toml::from_str(&read_to_string(path).await?)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,17 +1,19 @@
-use bytesize::ByteSize;
-use color_eyre::eyre::Result;
 use std::fs::create_dir_all;
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use subspace_sdk::PublicKey;
+
+use bytesize::ByteSize;
+use color_eyre::eyre::Result;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, fmt::format::FmtSpan, EnvFilter, Layer};
+
+use subspace_sdk::PublicKey;
 
 const KEEP_LAST_N_DAYS: usize = 7;
 
@@ -50,8 +52,10 @@ pub(crate) fn get_user_input(
         if condition(&user_input) {
             break user_input;
         }
-        if let Some(default) = default_value && user_input.is_empty() {
-            break default.to_string();
+        if let Some(default) = default_value {
+            if user_input.is_empty() {
+                break default.to_string();
+            }
         }
 
         println!("{error_msg}");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -123,7 +123,7 @@ pub(crate) fn support_message() -> String {
 
 pub(crate) fn install_tracing(is_verbose: bool) {
     let log_dir = custom_log_dir();
-    let _ = create_dir_all(log_dir.clone());
+    let _ = create_dir_all(&log_dir);
 
     let file_appender = RollingFileAppender::builder()
         .max_log_files(KEEP_LAST_N_DAYS)


### PR DESCRIPTION
This PR introduces a new logic that will be helpful for `subspace info` command in the future and for the communication between `plotting_progress` and `solution` subscriptions.
Basically, this PR introduces a new file called `summary.toml`, which stores 2 things (may be more in the future):
- how many blocks have farmed till now
- is initial plotting progress finished

It solves the following problems:
- The user may want to close the app and re-open it again. And the user will still want to know how many blocks they farmed in total. 
- to be implemented `subspace info` command should not start farming, yet retrieve info about the farmer. And currently, farming starts as soon as `Farmer` is built. So, the most efficient way to retrieve info related to farmer, is again to store them in a file imo.




This PR also:
- updates rust toolchain to the newest version
- organizes `use`s in a better way
- makes `solution subscriber` to wait for `initial plotting progress` to be completed, in order to start printing to the terminal. Thus, progress bar won't be printed again and we won't see buggy behavior in the TUI
