### PR TITLE
Node settings

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: fmt
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "array-bytes"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a913633b0c922e6b745072795f50d90ebea78ba31a57e2ac8c2fc7b50950949"
+checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
 name = "arrayref"
@@ -459,7 +459,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12e5fd123190ce1c2e559308a94c9bacad77907d4c6005d9e58fe1a0689e55e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.23"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "atty",
  "bitflags",
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1570,7 +1570,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.5",
+ "digest 0.10.6",
  "ff",
  "generic-array 0.14.6",
  "group",
@@ -2382,7 +2382,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2473,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",
@@ -2944,9 +2944,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kv-log-macro"
@@ -3351,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.41.0"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f079097a21ad017fc8139460630286f02488c8c13b26affb46623aa20d8845"
+checksum = "0d6874d66543c4f7e26e3b8ca9a6bead351563a13ab4fafd43c7927f7c0d6c12"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -3750,7 +3753,7 @@ dependencies = [
  "blake2s_simd",
  "blake3",
  "core2",
- "digest 0.10.5",
+ "digest 0.10.6",
  "multihash-derive",
  "serde",
  "serde-big-array",
@@ -6467,7 +6470,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -6476,7 +6479,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -6514,7 +6517,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
  "rand_core 0.6.4",
 ]
 
@@ -6827,7 +6830,7 @@ source = "git+https://github.com/subspace/substrate?rev=2ae536ab00f023fe311cb3ed
 dependencies = [
  "blake2",
  "byteorder",
- "digest 0.10.5",
+ "digest 0.10.6",
  "sha2 0.10.6",
  "sha3",
  "sp-std",
@@ -7461,6 +7464,7 @@ dependencies = [
  "dirs",
  "futures",
  "indicatif",
+ "libp2p-core",
  "serde",
  "serde_derive",
  "single-instance",
@@ -7680,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "subspace-sdk"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=301f58af6015910eb6075a715b453e5c43525a81#301f58af6015910eb6075a715b453e5c43525a81"
+source = "git+https://github.com/subspace/subspace-sdk?rev=fb2ddf8fe0131da211ec98a107ee3d65cbfed01c#fb2ddf8fe0131da211ec98a107ee3d65cbfed01c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8464,7 +8468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "digest 0.10.5",
+ "digest 0.10.6",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -9259,9 +9263,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ color-eyre = "0.6.2"
 dirs = "4.0.0"
 futures = "0.3.25"
 indicatif = "0.17.1"
+libp2p-core = "0.37.0"
 serde = "1.0.147"
 serde_derive = "1.0.147"
 single-instance = "0.3.3"
@@ -25,7 +26,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 whoami = "1.2.3"
 
-subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "301f58af6015910eb6075a715b453e5c43525a81" }
+subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "fb2ddf8fe0131da211ec98a107ee3d65cbfed01c" }
 
 [patch.crates-io]
 # TODO: Remove once chacha20poly1305 0.10 appears in libp2p's dependencies

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-09"
+channel = "nightly-2022-11-16"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,7 +9,7 @@ use crate::utils::{
 };
 
 const DEFAULT_PLOT_SIZE: &str = "100GB";
-const DEFAULT_CHAIN: &str = "gemini-2a";
+const DEFAULT_CHAIN: &str = "dev";
 
 pub(crate) fn init() -> Result<()> {
     let (config, config_path) = create_config()?;

--- a/src/commands/wipe.rs
+++ b/src/commands/wipe.rs
@@ -3,10 +3,11 @@ use color_eyre::eyre::Result;
 use subspace_sdk::{Node, PlotDescription};
 
 use crate::config::parse_config;
+use crate::summary::delete_summary;
 use crate::utils::node_directory_getter;
 
 pub(crate) async fn wipe() -> Result<()> {
-    let config_args = match parse_config() {
+    let config = match parse_config() {
         Ok(args) => args,
         Err(_) => {
             println!("could not read your config. You must have a valid config in order to wipe. Aborting...");
@@ -14,17 +15,19 @@ pub(crate) async fn wipe() -> Result<()> {
         }
     };
     let node_directory = node_directory_getter();
-    Node::wipe(node_directory).await?;
+    let _ = Node::wipe(node_directory).await;
     println!("Node is wiped!");
 
     // TODO: modify here when supporting multi-plot
     let plot = PlotDescription {
-        directory: config_args.farmer_config_args.plot.directory,
-        space_pledged: config_args.farmer_config_args.plot.space_pledged,
+        directory: config.farmer.plot_directory,
+        space_pledged: config.farmer.plot_size,
     };
 
     let _ = plot.wipe().await;
     println!("Farmer is wiped!");
+
+    delete_summary().await;
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ pub(crate) struct NodeConfig {
     pub(crate) unsafe_ws_external: bool,
 }
 
+/// structure for the `chain` field of the config toml file
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ChainConfig {
     pub(crate) dev: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,10 +6,14 @@ use std::{
 
 use bytesize::ByteSize;
 use color_eyre::eyre::{Report, Result};
+use libp2p_core::Multiaddr;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
-use subspace_sdk::PublicKey;
+use subspace_sdk::{
+    node::{Role, RpcMethods},
+    PublicKey,
+};
 
 /// structure of the config toml file
 #[derive(Deserialize, Serialize)]
@@ -36,10 +40,11 @@ pub(crate) struct NodeConfig {
     pub(crate) execution: String,
     pub(crate) blocks_pruning: u32,
     pub(crate) state_pruning: u32,
-    pub(crate) validator: bool,
+    pub(crate) role: Role,
     pub(crate) name: String,
-    pub(crate) port: String,
-    pub(crate) unsafe_ws_external: bool,
+    pub(crate) listen_addresses: Vec<Multiaddr>,
+    pub(crate) rpc_method: RpcMethods,
+    pub(crate) force_authoring: bool,
 }
 
 /// structure for the `chain` field of the config toml file
@@ -89,10 +94,11 @@ pub(crate) fn construct_config(
             execution: "wasm".to_owned(),
             blocks_pruning: 1024,
             state_pruning: 1024,
-            validator: true,
+            role: Role::Full,
             name: node_name.to_owned(),
-            port: "".to_owned(),
-            unsafe_ws_external: true, // not sure we need this
+            listen_addresses: vec![],
+            rpc_method: RpcMethods::Auto,
+            force_authoring: false,
         },
         chains: ChainConfig {
             dev: "that local node experience".to_owned(),

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -87,18 +87,21 @@ pub(crate) async fn update_summary(
     Ok(())
 }
 
+/// retrives how much space has user pledged to the network from the summary file
 #[instrument]
 pub(crate) async fn get_user_space_pledged() -> Result<ByteSize> {
     let summary = parse_summary(&summary_path()).await?;
     Ok(summary.user_space_pledged)
 }
 
+/// retrieves how many blocks have been farmed, from the summary file
 #[instrument]
 pub(crate) async fn get_farmed_block_count() -> Result<u64> {
     let summary = parse_summary(&summary_path()).await?;
     Ok(summary.farmed_block_count)
 }
 
+/// retrieves the status of the initial plotting, from the summary file
 #[instrument]
 pub(crate) async fn get_initial_plotting_progress() -> Result<bool> {
     let summary = parse_summary(&summary_path()).await?;
@@ -112,12 +115,13 @@ async fn parse_summary(path: &PathBuf) -> Result<FarmerSummary> {
     Ok(summary)
 }
 
-/// returns the path for the summary file
+/// deletes the summary file
 #[instrument]
 pub(crate) async fn delete_summary() {
     let _ = remove_file(summary_path()).await;
 }
 
+/// returns the path for the summary file
 #[instrument]
 fn summary_path() -> PathBuf {
     let summary_path =

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -9,7 +9,7 @@ use bytesize::ByteSize;
 use color_eyre::eyre::{Report, Result};
 use serde::{Deserialize, Serialize};
 use tokio::{
-    fs::{create_dir_all, read_to_string, File, OpenOptions},
+    fs::{create_dir_all, read_to_string, remove_file, File, OpenOptions},
     io::AsyncWriteExt,
 };
 use tracing::instrument;
@@ -80,16 +80,19 @@ pub(crate) async fn update_summary(
     Ok(())
 }
 
+#[instrument]
 pub(crate) async fn get_user_space_pledged() -> Result<ByteSize> {
     let summary = parse_summary(&summary_path()).await?;
     Ok(summary.user_space_pledged)
 }
 
+#[instrument]
 pub(crate) async fn get_farmed_block_count() -> Result<u64> {
     let summary = parse_summary(&summary_path()).await?;
     Ok(summary.farmed_block_count)
 }
 
+#[instrument]
 pub(crate) async fn get_initial_plotting_progress() -> Result<bool> {
     let summary = parse_summary(&summary_path()).await?;
     Ok(summary.initial_plotting_finished)
@@ -99,6 +102,11 @@ pub(crate) async fn get_initial_plotting_progress() -> Result<bool> {
 async fn parse_summary(path: &PathBuf) -> Result<FarmerSummary> {
     let summary: FarmerSummary = toml::from_str(&read_to_string(path).await?)?;
     Ok(summary)
+}
+
+#[instrument]
+pub(crate) async fn delete_summary() {
+    let _ = remove_file(summary_path()).await;
 }
 
 #[instrument]


### PR DESCRIPTION
This pr:
- uses all the fields in `settings.toml` now in node configuration (except the `execution`, for that, waiting on SDK)
- updates nightly version, `cargo doc` command now works 100% fine
- optimizes CI, so that macOS won't occasionally fail because of `protoc`
- gets rid of `gemini-2a`

Let's try to build executables after this PR, and if it succeeds, I'll update the readme accordingly for downloading instructions