### PR TITLE
config validity checks at each parsing

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -71,7 +71,7 @@ fn fill_config_from_user_inputs(mut config: File) -> Result<()> {
         ),
         Some(DEFAULT_PLOT_SIZE),
         is_valid_size,
-        "could not parse the value! Please enter a valid size.",
+        "could not parse the value! Please enter a valid size. The size should also be bigger than 1GB.",
     )?;
 
     let chain = get_user_input(

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ use subspace_sdk::{
     PublicKey,
 };
 
+use crate::utils::{is_valid_chain, is_valid_node_name};
+
 /// structure of the config toml file
 #[derive(Deserialize, Serialize)]
 pub(crate) struct Config {
@@ -115,6 +117,24 @@ pub(crate) fn parse_config() -> Result<Config> {
     let config_path = config_path.join("subspace-cli").join("settings.toml");
 
     let config: Config = toml::from_str(&std::fs::read_to_string(config_path)?)?;
+
+    // validity checks
+    if config.farmer.plot_size < "1GB".parse::<ByteSize>().expect("hardcoded value is true") {
+        return Err(Report::msg("size should be bigger than 1GB!"));
+    }
+    if !is_valid_chain(&config.node.chain) {
+        return Err(Report::msg("chain is not recognized!"));
+    }
+    if !config.farmer.plot_directory.is_dir() {
+        return Err(Report::msg(
+            "Plot directory could not be found. Please check if that folder exists",
+        ));
+    }
+    if !is_valid_node_name(&config.node.name) {
+        return Err(Report::msg(
+            "Node nome is either empty or includes non-ascii characters",
+        ));
+    }
 
     Ok(config)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,7 +92,10 @@ pub(crate) fn is_valid_location(location: &str) -> bool {
 
 /// utilize `ByteSize` crate for the validation
 pub(crate) fn is_valid_size(size: &str) -> bool {
-    size.parse::<ByteSize>().is_ok()
+    let Ok(size) = size.parse::<ByteSize>() else {
+        return false;
+    };
+    size < "1GB".parse::<ByteSize>().expect("hardcoded value is true")
 }
 
 /// user can only specify a valid chain
@@ -134,7 +137,7 @@ fn custom_log_dir() -> PathBuf {
 /// in case of any error, display this message
 pub(crate) fn support_message() -> String {
     format!(
-        "This is a bug, please submit it to our forums: {}",
+        "If you think this is a bug, please submit it to our forums: {}",
         ansi_term::Style::new()
             .underline()
             .paint("https://forum.subspace.network")


### PR DESCRIPTION
This will allow us to check the validity of the config at each parse operation. So that, possible erroneous scenarios would be prevented:
1. user creates a valid config via `init` command
2. then modifies the config as they please (but it's not valid anymore.. Oh dear user! What have you done?!)
3. farm function crashes with a weird message, because config is not valid
4. many other things crash too, it's chaos now
 
