### PR TITLE
update version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9144,7 +9144,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-cli"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "ansi_term",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-cli"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
`init` was still showing `v0.1.0`, let's fix that :)