### PR TITLE
Issue template and code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,7 +41,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com) # TODO: fix this link
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/subspace/subspace-cli/blob/main/CODE_OF_CONDUCT.md) # TODO: fix this link
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,9 @@
-name: Bug Report
-description: If something is not working as expected... 
-title: "[Bug]: "
+name: 🐞 Bug Report
+description: If something is not working as expected...🔍
+title: "🐞 [Bug]: "
 labels: ["bug"]
 assignees:
-  - ozgunozerk 
+  - ozgunozerk
 body:
   - type: markdown
     attributes:
@@ -13,10 +13,10 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: if you want, you can include screenshots as well :) 
+      description: if you want, you can include screenshots as well :)
     validations:
       required: true
-  - type: input  
+  - type: input
     id: version
     attributes:
       label: Version
@@ -29,7 +29,7 @@ body:
       label: platform
       description: On which operating system did this bug emerged?
       options:
-        - linux 
+        - linux
         - windows
         - macos
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: If something is not working as expected... 
+title: "[Bug]: "
+labels: ["bug"]
+assignees:
+  - ozgunozerk 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: if you want, you can include screenshots as well :) 
+    validations:
+      required: true
+  - type: input  
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: platform
+      description: On which operating system did this bug emerged?
+      options:
+        - linux 
+        - windows
+        - macos
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead? What was the expected behavior?
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com) # TODO: fix this link
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature Request 
+description: If you have a great thing on your mind  
+title: "[Feature Request]: "
+labels: ["enhancement"]
+assignees:
+  - ozgunozerk 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill this feature request! 
+  - type: textarea
+    id: feature 
+    attributes:
+      label: What is the feature you would like to see? 
+      description: please explain all the details :) 
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/subspace/subspace-cli/blob/main/CODE_OF_CONDUCT.md) # TODO: fix this link
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,19 +1,19 @@
-name: Feature Request 
-description: If you have a great thing on your mind  
-title: "[Feature Request]: "
+name: 🎁 Feature Request
+description: If you have a great thing on your mind ⚡️
+title: "🎁 [Feature Request]: "
 labels: ["enhancement"]
 assignees:
-  - ozgunozerk 
+  - ozgunozerk
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill this feature request! 
+        Thanks for taking the time to fill this feature request!
   - type: textarea
-    id: feature 
+    id: feature
     attributes:
-      label: What is the feature you would like to see? 
-      description: please explain all the details :) 
+      label: What is the feature you would like to see?
+      description: please explain all the details :)
     validations:
       required: true
   - type: checkboxes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Code of Conduct
+
+Subspace perceives trust, respect, collaboration and transparency as core values. Our community welcomes participants from around the world with different experiences, unique perspectives, and great ideas to share.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Attempting collaboration before conflict
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- Violence, threats of violence, or inciting others to commit self-harm
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, intentionally spreading misinformation, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Abuse of the reporting process to intentionally harass or exclude others
+- Advocating for, or encouraging, any of the above behavior
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), [version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).


### PR DESCRIPTION
Please review thoroughly @achiurizo @jfrank-summit .

For the code of conduct, there was this part:
```
## Enforcement

Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting us anonymously through [this form](https://goo.gl/forms/chVYUnA4bP70WGsL2). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.

Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.

If you are unsure whether an incident is a violation, or whether the space where the incident took place is covered by our Code of Conduct, **we encourage you to still report it**. We would prefer to have a few extra reports where we decide to take no action, than to leave an incident go unnoticed and unresolved that may result in an individual or group to feel like they can no longer participate in the community. Reports deemed as not a violation will also allow us to improve our Code of Conduct and processes surrounding it. If you witness a dangerous situation or someone in distress, we encourage you to report even if you are only an observer.
```

but I evicted it, since we don't have setup/link regarding an anonymous google form submission.

We can merge this as is, and then include this `Enforcement` part if you like.


@nazar-pc I tagged you, since we have a `CONTRIBUTING.md` but that does not include `CODE_OF_CONDUCT.md`, and I believe at our scale, it might be helpful.
