### PR TITLE
Clear unwraps

### DIFF
--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -206,9 +206,9 @@ fn syncing_progress_bar(current_block: u64, total_blocks: u64) -> ProgressBar {
              {bps}, {msg}, ETA: {eta_precise} ",
         )
         .expect("hardcoded template is correct")
-        // .with_key("bps", |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| {
-        //     write!(w, "{:.2}bps", state.per_sec()).expect("terminal write should succeed")
-        // })
+        .with_key("bps", |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| {
+            write!(w, "{:.2}bps", state.per_sec()).expect("terminal write should succeed")
+        })
         // More of those: https://github.com/sindresorhus/cli-spinners/blob/45cef9dff64ac5e36b46a194c68bccba448899ac/spinners.json
         .tick_strings(&["◜", "◠", "◝", "◞", "◡", "◟"])
         // From here: https://github.com/console-rs/indicatif/blob/d54fb0ef4c314b3c73fc94372a97f14c4bd32d9e/examples/finebars.rs#L10

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -125,7 +125,7 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
                             "{spinner} [{elapsed_precise}] {percent}% [{bar:40.cyan/blue}]
                   ({bytes}/{total_bytes}) {msg}",
                         )
-                        .unwrap()
+                        .expect("hardcoded template is correct")
                         .progress_chars("=> "),
                     );
                     progress_bar.finish_with_message("Initial plotting finished!");
@@ -183,7 +183,7 @@ fn plotting_progress_bar(total_size: u64) -> ProgressBar {
             " {spinner:2.green} [{elapsed_precise}] {percent}% [{wide_bar:.yellow}] ({pos}/{len}) \
              {bytes_per_sec}, {msg}, ETA: {eta_precise} ",
         )
-        .unwrap()
+        .expect("hardcoded template is correct")
         // More of those: https://github.com/sindresorhus/cli-spinners/blob/45cef9dff64ac5e36b46a194c68bccba448899ac/spinners.json
         .tick_strings(&["◜", "◠", "◝", "◞", "◡", "◟"])
         // From here: https://github.com/console-rs/indicatif/blob/d54fb0ef4c314b3c73fc94372a97f14c4bd32d9e/examples/finebars.rs#L10
@@ -202,10 +202,10 @@ fn syncing_progress_bar(current_block: u64, total_blocks: u64) -> ProgressBar {
             " {spinner:2.green} [{elapsed_precise}] {percent}% [{wide_bar:.cyan}] ({pos}/{len}) \
              {bps}, {msg}, ETA: {eta_precise} ",
         )
-        .unwrap()
-        .with_key("bps", |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| {
-            write!(w, "{:.2}bps", state.per_sec()).unwrap()
-        })
+        .expect("hardcoded template is correct")
+        // .with_key("bps", |state: &indicatif::ProgressState, w: &mut dyn std::fmt::Write| {
+        //     write!(w, "{:.2}bps", state.per_sec()).expect("terminal write should succeed")
+        // })
         // More of those: https://github.com/sindresorhus/cli-spinners/blob/45cef9dff64ac5e36b46a194c68bccba448899ac/spinners.json
         .tick_strings(&["◜", "◠", "◝", "◞", "◡", "◟"])
         // From here: https://github.com/console-rs/indicatif/blob/d54fb0ef4c314b3c73fc94372a97f14c4bd32d9e/examples/finebars.rs#L10

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -129,7 +129,6 @@ async fn subscribe_to_plotting_progress(
     sector_size_bytes: u64,
 ) {
     tokio::spawn({
-        let summary = summary.clone();
         async move {
             for (plot_id, plot) in farmer.iter_plots().await.enumerate() {
                 println!("Initial plotting for plot: #{plot_id} ({})", plot.directory().display());

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -40,9 +40,9 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
     // raise file limit
     raise_fd_limit();
 
-    println!("Starting node ...");
     let Config { chain, farmer: farmer_config, node: node_config } = validate_config()?;
 
+    println!("Starting node ...");
     let chain = match chain {
         ChainConfig::Gemini3b =>
             chain_spec::gemini_3b().expect("cannot extract the gemini3b chain spec from SDK"),
@@ -57,26 +57,7 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
     println!("Node started successfully!");
 
     if !is_verbose {
-        let mut syncing_progress = node
-            .subscribe_syncing_progress()
-            .await
-            .map_err(|err| eyre!("Failed to subscribe to node syncing: {err}"))?
-            .map_ok(|SyncingProgress { at, target, status: _ }| (target as _, at as _))
-            .map_err(|err| eyre!("Sync failed because: {err}"));
-
-        let Some(syncing_result) = syncing_progress.next().await else {
-            return Err(eyre!("backoff mechanism timed out for node syncing on the SDK side"));
-        };
-        let (target_block, current_block) = syncing_result?;
-        let syncing_progress_bar = syncing_progress_bar(current_block, target_block);
-
-        while let Some(stream_result) = syncing_progress.next().await {
-            let (target_block, current_block) = stream_result?;
-            syncing_progress_bar.set_position(current_block);
-            syncing_progress_bar.set_length(target_block);
-        }
-
-        syncing_progress_bar.finish_with_message("Syncing is done!");
+        subscribe_to_node_syncing(node.clone()).await?;
     } else {
         node.sync().await.map_err(|err| eyre!("Node syncing failed: {err}"))?;
     }
@@ -100,81 +81,123 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
     if !is_verbose {
         let is_initial_progress_finished = Arc::new(AtomicBool::new(false));
         let sector_size_bytes = farmer.get_info().await.map_err(Report::msg)?.sector_size;
-        let farmer_clone = farmer.clone();
-        let finished_flag = is_initial_progress_finished.clone();
-
-        // initial plotting progress subscriber
-        tokio::spawn({
-            let summary = summary.clone();
-            async move {
-                for (plot_id, plot) in farmer_clone.iter_plots().await.enumerate() {
-                    println!(
-                        "Initial plotting for plot: #{plot_id} ({})",
-                        plot.directory().display()
-                    );
-                    let progress_bar = plotting_progress_bar(plot.allocated_space().as_u64());
-                    plot.subscribe_initial_plotting_progress()
-                        .await
-                        .for_each(|progress| {
-                            let pb_clone = progress_bar.clone();
-                            async move {
-                                let current_bytes = progress.current_sector * sector_size_bytes;
-                                pb_clone.set_position(current_bytes);
-                            }
-                        })
-                        .await;
-                    progress_bar.set_style(
-                        ProgressStyle::with_template(
-                            "{spinner} [{elapsed_precise}] {percent}% [{bar:40.cyan/blue}]
-                  ({bytes}/{total_bytes}) {msg}",
-                        )
-                        .expect("hardcoded template is correct")
-                        .progress_chars("=> "),
-                    );
-                    progress_bar.finish_with_message("Initial plotting finished!");
-                    finished_flag.store(true, Ordering::Relaxed);
-                    let _ = summary.update(Some(true), None).await; // ignore the error, since we will abandon this mechanism soon
-                }
-            }
-        });
-
-        // solution subscriber
-        tokio::spawn({
-            let farmer = farmer.clone();
-            let summary = summary.clone();
-            async move {
-                let farmed_blocks = summary
-                    .get_farmed_block_count()
-                    .await
-                    .expect("couldn't read farmed blocks count from summary");
-                let farmed_block_count = Arc::new(AtomicU64::new(farmed_blocks));
-                for plot in farmer.iter_plots().await {
-                    plot.subscribe_new_solutions()
-                        .await
-                        .for_each(|solutions| {
-                            let farmed_block_count = &farmed_block_count;
-                            let is_initial_progress_finished = &is_initial_progress_finished;
-                            let summary = summary.clone();
-                            async move {
-                                if !solutions.solutions.is_empty() {
-                                    let total_farmed =
-                                        farmed_block_count.fetch_add(1, Ordering::Relaxed);
-                                    let _ = summary.update(None, Some(total_farmed)).await; // ignore the error, since we will abandon this mechanism
-                                    if is_initial_progress_finished.load(Ordering::Relaxed) {
-                                        println!(
-                                            "You have farmed {total_farmed} block(s) in total!"
-                                        );
-                                    }
-                                }
-                            }
-                        })
-                        .await
-                }
-            }
-        });
+        subscribe_to_plotting_progress(
+            summary.clone(),
+            farmer.clone(),
+            is_initial_progress_finished.clone(),
+            sector_size_bytes,
+        )
+        .await;
+        subscribe_to_solutions(
+            summary.clone(),
+            farmer.clone(),
+            is_initial_progress_finished.clone(),
+        )
+        .await;
     }
 
     Ok((farmer, node, instance))
+}
+
+async fn subscribe_to_node_syncing(node: Node) -> Result<()> {
+    let mut syncing_progress = node
+        .subscribe_syncing_progress()
+        .await
+        .map_err(|err| eyre!("Failed to subscribe to node syncing: {err}"))?
+        .map_ok(|SyncingProgress { at, target, status: _ }| (target as _, at as _))
+        .map_err(|err| eyre!("Sync failed because: {err}"));
+
+    if let Some(syncing_result) = syncing_progress.next().await {
+        let (target_block, current_block) = syncing_result?;
+        let syncing_progress_bar = syncing_progress_bar(current_block, target_block);
+
+        while let Some(stream_result) = syncing_progress.next().await {
+            let (target_block, current_block) = stream_result?;
+            syncing_progress_bar.set_position(current_block);
+            syncing_progress_bar.set_length(target_block);
+        }
+
+        syncing_progress_bar.finish_with_message("Syncing is done!");
+    }
+    Ok(())
+}
+
+async fn subscribe_to_plotting_progress(
+    summary: Summary,
+    farmer: Farmer,
+    is_initial_progress_finished: Arc<AtomicBool>,
+    sector_size_bytes: u64,
+) {
+    tokio::spawn({
+        let summary = summary.clone();
+        async move {
+            for (plot_id, plot) in farmer.iter_plots().await.enumerate() {
+                println!("Initial plotting for plot: #{plot_id} ({})", plot.directory().display());
+                let progress_bar = plotting_progress_bar(plot.allocated_space().as_u64());
+                plot.subscribe_initial_plotting_progress()
+                    .await
+                    .for_each(|progress| {
+                        let pb_clone = progress_bar.clone();
+                        async move {
+                            let current_bytes = progress.current_sector * sector_size_bytes;
+                            pb_clone.set_position(current_bytes);
+                        }
+                    })
+                    .await;
+                progress_bar.set_style(
+                    ProgressStyle::with_template(
+                        "{spinner} [{elapsed_precise}] {percent}% [{bar:40.cyan/blue}]
+                  ({bytes}/{total_bytes}) {msg}",
+                    )
+                    .expect("hardcoded template is correct")
+                    .progress_chars("=> "),
+                );
+                progress_bar.finish_with_message("Initial plotting finished!");
+                is_initial_progress_finished.store(true, Ordering::Relaxed);
+                let _ = summary.update(Some(true), None).await; // ignore the
+                                                                // error, since
+                                                                // we will abandon
+                                                                // this mechanism
+                                                                // soon
+            }
+        }
+    });
+}
+
+async fn subscribe_to_solutions(
+    summary: Summary,
+    farmer: Farmer,
+    is_initial_progress_finished: Arc<AtomicBool>,
+) {
+    tokio::spawn({
+        async move {
+            let farmed_blocks = summary
+                .get_farmed_block_count()
+                .await
+                .expect("couldn't read farmed blocks count from summary");
+            let farmed_block_count = Arc::new(AtomicU64::new(farmed_blocks));
+            for plot in farmer.iter_plots().await {
+                plot.subscribe_new_solutions()
+                    .await
+                    .for_each(|solutions| {
+                        let farmed_block_count = &farmed_block_count;
+                        let is_initial_progress_finished = &is_initial_progress_finished;
+                        let summary = summary.clone();
+                        async move {
+                            if !solutions.solutions.is_empty() {
+                                let total_farmed =
+                                    farmed_block_count.fetch_add(1, Ordering::Relaxed);
+                                let _ = summary.update(None, Some(total_farmed)).await; // ignore the error, since we will abandon this mechanism
+                                if is_initial_progress_finished.load(Ordering::Relaxed) {
+                                    println!("You have farmed {total_farmed} block(s) in total!");
+                                }
+                            }
+                        }
+                    })
+                    .await
+            }
+        }
+    });
 }
 
 /// nice looking progress bar for the initial plotting :)

--- a/src/commands/wipe.rs
+++ b/src/commands/wipe.rs
@@ -3,38 +3,49 @@ use subspace_sdk::{Node, PlotDescription};
 
 use crate::config::parse_config;
 use crate::summary::delete_summary;
-use crate::utils::node_directory_getter;
+use crate::utils::{node_directory_getter, plot_directory_getter};
 
 /// implementation of the `wipe` command
 ///
 /// wipes both farmer and node files (basically a fresh start)
 pub(crate) async fn wipe() -> Result<()> {
     let config = match parse_config() {
-        Ok(args) => args,
+        Ok(args) => Some(args),
         Err(_) => {
             println!(
-                "could not read your config. You must have a valid config in order to wipe. \
-                 Aborting..."
+                "could not read your config. There could have been a breaking change, or you may \
+                 have an ill-formed config file. Wipe will continue... \n{}",
+                ansi_term::Style::new().underline().paint(
+                    "However, if you have set a custom location for your plots, you will need to \
+                     manually delete your plots!"
+                )
             );
-            return Ok(());
+            None
         }
     };
     let node_directory = node_directory_getter();
     let _ = Node::wipe(node_directory).await;
-    println!("Node is wiped!");
 
     // TODO: modify here when supporting multi-plot
-    match PlotDescription::new(config.farmer.plot_directory, config.farmer.plot_size) {
-        Ok(plot) => {
-            let _ = plot.wipe().await;
+    // if config can be read, delete the farmer using the path in the config, else,
+    // delete the default location
+    if let Some(config) = config {
+        match PlotDescription::new(config.farmer.plot_directory, config.farmer.plot_size) {
+            Ok(plot) => {
+                let _ = plot.wipe().await;
+            }
+            Err(err) => println!(
+                "Skipping wiping plot. Got error while constructing the plot reference: {err}"
+            ),
         }
-        Err(err) => println!("Skipping wiping plot. Got error while constructing it: {err}"),
+        let _ = config.farmer.cache.wipe().await;
+    } else {
+        let _ = tokio::fs::remove_dir_all(plot_directory_getter()).await;
     }
 
-    let _ = config.farmer.cache.wipe().await;
-    println!("Farmer is wiped!");
-
     delete_summary().await;
+
+    println!("Wipe successful!");
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,16 +40,16 @@ impl NodeConfig {
                 .network(
                     node::NetworkBuilder::new()
                         .listen_addresses(vec![
-                            "/ip6/::/tcp/30333".parse().unwrap(),
-                            "/ip4/0.0.0.0/tcp/30333".parse().unwrap(),
+                            "/ip6/::/tcp/30333".parse().expect("hardcoded value is true"),
+                            "/ip4/0.0.0.0/tcp/30333".parse().expect("hardcoded value is true"),
                         ])
                         .name(node_name)
                         .enable_mdns(true),
                 )
                 .rpc(
                     node::RpcBuilder::new()
-                        .http("127.0.0.1:9933".parse().unwrap())
-                        .ws("127.0.0.1:9944".parse().unwrap())
+                        .http("127.0.0.1:9933".parse().expect("hardcoded value is true"))
+                        .ws("127.0.0.1:9944".parse().expect("hardcoded value is true"))
                         .cors(vec![
                             "http://localhost:*".to_owned(),
                             "http://127.0.0.1:*".to_owned(),
@@ -59,8 +59,8 @@ impl NodeConfig {
                         ]),
                 )
                 .dsn(node::DsnBuilder::new().listen_addresses(vec![
-                    "/ip6/::/tcp/30433".parse().unwrap(),
-                    "/ip4/0.0.0.0/tcp/30433".parse().unwrap(),
+                    "/ip6/::/tcp/30433".parse().expect("hardcoded value is true"),
+                    "/ip4/0.0.0.0/tcp/30433".parse().expect("hardcoded value is true"),
                 ]))
                 .execution_strategy(node::ExecutionStrategy::AlwaysWasm)
                 .offchain_worker(node::OffchainWorkerBuilder::new().enabled(true))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,17 +115,21 @@ pub(crate) fn size_parser(size: &str) -> Result<ByteSize> {
 
 /// generates a plot path from the given path
 pub(crate) fn plot_directory_getter() -> PathBuf {
-    dirs::data_dir().unwrap().join("subspace-cli").join("plots")
+    data_dir_getter().join("plots")
 }
 
 /// generates a cache path from the given path
 pub(crate) fn cache_directory_getter() -> PathBuf {
-    dirs::data_dir().unwrap().join("subspace-cli").join("cache")
+    data_dir_getter().join("cache")
 }
 
 /// generates a node path from the given path
 pub(crate) fn node_directory_getter() -> PathBuf {
-    dirs::data_dir().unwrap().join("subspace-cli").join("node")
+    data_dir_getter().join("node")
+}
+
+fn data_dir_getter() -> PathBuf {
+    dirs::data_dir().expect("data folder must be present in every major OS").join("subspace-cli")
 }
 
 /// returns OS specific log directory


### PR DESCRIPTION
This PR:
- gets rid of the `unwrap()`s in the code (excluding tests)
- relaxes the wipe criteria, so even when there is a breaking change, the `wipe` command will attempt to remove the plots in the default directory. And prints a nice warning message as:
```
                "could not read your config. There could have been a breaking change, or you may \
                 have an ill-formed config file. Wipe will continue... \n",
                 "However, if you have set a custom location for your plots, you will need to \
                  manually delete your plots!"
```