### PR TITLE
Recursive config path creation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::fs::{create_dir, File};
+use std::fs::{create_dir_all, File};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -157,11 +157,9 @@ pub(crate) fn create_config() -> Result<(File, PathBuf)> {
         .expect("couldn't get the default config directory!")
         .join("subspace-cli");
 
-    if let Err(err) = create_dir(&config_path) {
-        // ignore the `AlreadyExists` error
-        if err.kind() != std::io::ErrorKind::AlreadyExists {
-            return Err(eyre!("could not create the directory, because: {err}"));
-        }
+    if let Err(err) = create_dir_all(&config_path) {
+        let config_path = config_path.to_str().expect("couldn't get subspace-cli config path!");
+        return Err(eyre!("could not create the directory: `{config_path}`, because: {err}"));
     }
 
     let file = File::create(config_path.join("settings.toml"))?;


### PR DESCRIPTION
There is a problem with `subscape-cli init` if there is no `.config` path in your `$HOME`, in this case, you will get such error:
```
# ./subspace-cli init
Error: could not create the directory, because: No such file or directory (os error 2)
```
This happens because `create_dir` can't produce recursive directories creation so this command will fail.

So, there was changed:
- `create_dir` to `create_dir_all` in the `create_config` step. 
- `AlreadyExists` error check was dropped because `create_dir_all` don't raise this error.
- Added `config_path` to error logging for debug purposes 