### PR TITLE
update error message and improve bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,15 +23,18 @@ body:
       description: What version of our software are you running?
     validations:
       required: true
-  - type: dropdown
+  - type: checkboxes 
     id: platform
     attributes:
       label: platform
       description: On which operating system did this bug emerged?
       options:
-        - linux
-        - windows
-        - macos
+        - label: linux
+          required: false
+        - label: windows
+          required: false
+        - label: macos
+          required: false
   - type: textarea
     id: expected
     attributes:

--- a/src/commands/wipe.rs
+++ b/src/commands/wipe.rs
@@ -13,8 +13,7 @@ pub(crate) async fn wipe() -> Result<()> {
         Ok(args) => Some(args),
         Err(_) => {
             println!(
-                "could not read your config. There could have been a breaking change, or you may \
-                 have an ill-formed config file. Wipe will continue... \n{}",
+                "could not read your config. Wipe will still continue... \n{}",
                 ansi_term::Style::new().underline().paint(
                     "However, if you have set a custom location for your plots, you will need to \
                      manually delete your plots!"


### PR DESCRIPTION
- improves bug issue template via allowing multiple selects for the platforms
- simplifies error message for wipe command in case of `subspace-cli` folder is missing