### PR TITLE
Config revamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9568,7 +9568,7 @@ dependencies = [
  "bytesize-serde",
  "clap",
  "color-eyre",
- "derive_builder 0.12.0",
+ "derivative",
  "dirs",
  "fdlimit",
  "futures 0.3.26",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9563,7 +9563,6 @@ dependencies = [
 name = "subspace-cli"
 version = "0.1.8"
 dependencies = [
- "ansi_term",
  "bytesize",
  "bytesize-serde",
  "clap",
@@ -9574,6 +9573,7 @@ dependencies = [
  "futures 0.3.26",
  "indicatif",
  "libp2p-core 0.38.0",
+ "owo-colors",
  "serde",
  "serde_derive",
  "single-instance",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ bytesize = "1.1"
 bytesize-serde = "0.2"
 clap = { version = "4.1.1", features = ["derive"] }
 color-eyre = "0.6.2"
-derive_builder = "0.12.0"
+derivative = "2.2.0"
 dirs = "4.0.0"
 fdlimit = "0.2"
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.8"
 edition = "2021"
 
 [dependencies]
-ansi_term = "0.12.1"
 bytesize = "1.1"
 bytesize-serde = "0.2"
 clap = { version = "4.1.1", features = ["derive"] }
@@ -15,6 +14,7 @@ fdlimit = "0.2"
 futures = "0.3"
 indicatif = { version = "0.17.1", features = ["improved_unicode"] }
 libp2p-core = "0.38"
+owo-colors = "3.5.0"
 serde = "1"
 serde_derive = "1"
 single-instance = "0.3.3"

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -10,7 +10,7 @@ use subspace_sdk::node::SyncingProgress;
 use subspace_sdk::{chain_spec, Farmer, Node, PlotDescription};
 use tracing::instrument;
 
-use crate::config::{validate_config, ChainConfig, Config};
+use crate::config::{validate_config, CliChainConfig, Config};
 use crate::summary::Summary;
 use crate::utils::{install_tracing, raise_fd_limit};
 
@@ -45,14 +45,15 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
 
     println!("Starting node ...");
     let chain_spec = match chain {
-        ChainConfig::Gemini3c =>
+        CliChainConfig::Gemini3c =>
             chain_spec::gemini_3c().expect("cannot extract the gemini3c chain spec from SDK"),
-        ChainConfig::Dev =>
+        CliChainConfig::Dev =>
             chain_spec::dev_config().expect("cannot extract the dev chain spec from SDK"),
-        ChainConfig::DevNet =>
+        CliChainConfig::DevNet =>
             chain_spec::devnet_config().expect("cannot extrat the devnet chain spec from SDK"),
     };
 
+    // TODO: revamp below accordingly
     let node = node_config
         .node
         .build(node_config.directory, chain_spec)

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -2,12 +2,12 @@ use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
-use color_eyre::eyre::{eyre, Report, Result, WrapErr};
+use color_eyre::eyre::{eyre, Report, Result};
 use futures::prelude::*;
 use indicatif::{ProgressBar, ProgressStyle};
 use single_instance::SingleInstance;
 use subspace_sdk::node::SyncingProgress;
-use subspace_sdk::{chain_spec, Farmer, Node, PlotDescription};
+use subspace_sdk::{Farmer, Node};
 use tracing::instrument;
 
 use crate::config::{validate_config, ChainConfig, Config};
@@ -26,7 +26,10 @@ pub(crate) const SINGLE_INSTANCE: &str = ".subspaceFarmer";
 /// lastly, depending on the verbosity, it subscribes to plotting progress and
 /// new solutions
 #[instrument]
-pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstance)> {
+pub(crate) async fn farm(
+    is_verbose: bool,
+    executor: bool,
+) -> Result<(Farmer, Node, SingleInstance)> {
     install_tracing(is_verbose);
     color_eyre::install()?;
 
@@ -41,25 +44,15 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
     // raise file limit
     raise_fd_limit();
 
-    let Config { chain, farmer: farmer_config, node: node_config } = validate_config()?;
+    let Config { chain, farmer: farmer_config, node: mut node_config } = validate_config()?;
+
+    // apply advanced options (flags)
+    if executor {
+        node_config.advanced.executor = true;
+    }
 
     println!("Starting node ...");
-    let chain_spec = match chain {
-        ChainConfig::Gemini3c =>
-            chain_spec::gemini_3c().expect("cannot extract the gemini3c chain spec from SDK"),
-        ChainConfig::Dev =>
-            chain_spec::dev_config().expect("cannot extract the dev chain spec from SDK"),
-        ChainConfig::DevNet =>
-            chain_spec::devnet_config().expect("cannot extrat the devnet chain spec from SDK"),
-    };
-
-    // TODO: revamp below accordingly
-    let node = node_config
-        .node
-        .build(node_config.directory, chain_spec)
-        .await
-        .expect("error building the node");
-
+    let node = node_config.build(chain.clone()).await.expect("error building the node");
     println!("Node started successfully!");
 
     if !matches!(chain, ChainConfig::Dev) {
@@ -73,17 +66,7 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
     let summary = Summary::new(Some(farmer_config.plot_size)).await?;
 
     println!("Starting farmer ...");
-    let farmer = farmer_config
-        .farmer
-        .build(
-            farmer_config.address,
-            node.clone(),
-            &[PlotDescription::new(farmer_config.plot_directory, farmer_config.plot_size)
-                .wrap_err("Plot size is too low")?],
-            farmer_config.cache,
-        )
-        .await?;
-
+    let farmer = farmer_config.build(chain, node.clone()).await?;
     println!("Farmer started successfully!");
 
     if !is_verbose {

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -10,7 +10,7 @@ use subspace_sdk::node::SyncingProgress;
 use subspace_sdk::{chain_spec, Farmer, Node, PlotDescription};
 use tracing::instrument;
 
-use crate::config::{validate_config, CliChainConfig, Config};
+use crate::config::{validate_config, ChainConfig, Config};
 use crate::summary::Summary;
 use crate::utils::{install_tracing, raise_fd_limit};
 
@@ -45,11 +45,11 @@ pub(crate) async fn farm(is_verbose: bool) -> Result<(Farmer, Node, SingleInstan
 
     println!("Starting node ...");
     let chain_spec = match chain {
-        CliChainConfig::Gemini3c =>
+        ChainConfig::Gemini3c =>
             chain_spec::gemini_3c().expect("cannot extract the gemini3c chain spec from SDK"),
-        CliChainConfig::Dev =>
+        ChainConfig::Dev =>
             chain_spec::dev_config().expect("cannot extract the dev chain spec from SDK"),
-        CliChainConfig::DevNet =>
+        ChainConfig::DevNet =>
             chain_spec::devnet_config().expect("cannot extrat the devnet chain spec from SDK"),
     };
 

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use color_eyre::eyre::{eyre, Report, Result};
 use futures::prelude::*;
 use indicatif::{ProgressBar, ProgressStyle};
+use owo_colors::OwoColorize;
 use single_instance::SingleInstance;
 use subspace_sdk::node::SyncingProgress;
 use subspace_sdk::{Farmer, Node};
@@ -48,11 +49,7 @@ pub(crate) async fn farm(
 
     // apply advanced options (flags)
     if executor {
-        println!(
-            "Setting the {} flag for the node...",
-            ansi_term::Style::new().underline().paint("executor")
-        );
-
+        println!("Setting the {} flag for the node...", "executor".underline());
         node_config.advanced.executor = true;
     }
 

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -48,6 +48,11 @@ pub(crate) async fn farm(
 
     // apply advanced options (flags)
     if executor {
+        println!(
+            "Setting the {} flag for the node...",
+            ansi_term::Style::new().underline().paint("executor")
+        );
+
         node_config.advanced.executor = true;
     }
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::{eyre, Report, Result};
+use color_eyre::eyre::{Context, Result};
 use single_instance::SingleInstance;
 
 use crate::commands::farm::SINGLE_INSTANCE;
@@ -8,7 +8,8 @@ use crate::summary::Summary;
 ///
 /// informs the user about the current farming instance
 pub(crate) async fn info() -> Result<()> {
-    let instance = SingleInstance::new(SINGLE_INSTANCE).map_err(Report::msg)?;
+    let instance =
+        SingleInstance::new(SINGLE_INSTANCE).context("failed to initialize single instance")?;
     if !instance.is_single() {
         println!("A farmer instance is active!");
     } else {
@@ -19,21 +20,25 @@ pub(crate) async fn info() -> Result<()> {
 
     println!(
         "You have pledged to the network: {}",
-        summary.get_user_space_pledged().await.map_err(|_| eyre!(
-            "Couldn't read the summary file, are you sure you ran the farm command?"
-        ))?
+        summary
+            .get_user_space_pledged()
+            .await
+            .context("Couldn't read the summary file, are you sure you ran the farm command?")?
     );
 
     println!(
         "Total farmed blocks: {}",
-        summary.get_farmed_block_count().await.map_err(|_| eyre!(
-            "Couldn't read the summary file, are you sure you ran the farm command?"
-        ))?
+        summary
+            .get_farmed_block_count()
+            .await
+            .context("Couldn't read the summary file, are you sure you ran the farm command?")?
     );
 
-    if summary.get_initial_plotting_progress().await.map_err(|_| {
-        eyre!("Couldn't read the summary file, are you sure you ran the farm command?")
-    })? {
+    if summary
+        .get_initial_plotting_progress()
+        .await
+        .context("Couldn't read the summary file, are you sure you ran the farm command?")?
+    {
         println!("Initial plotting is finished!");
     } else {
         println!("Initial plotting is not finished...");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::{Context, Result};
 use subspace_sdk::farmer::CacheDescription;
 
 use crate::config::{
-    create_config, CliChainConfig, CliConfig, CliFarmerConfig, CliNodeConfig, DEFAULT_PLOT_SIZE,
+    create_config, ChainConfig, Config, FarmerConfig, NodeConfig, DEFAULT_PLOT_SIZE,
 };
 use crate::utils::{
     cache_directory_getter, get_user_input, node_directory_getter, node_name_parser,
@@ -39,7 +39,7 @@ pub(crate) fn init() -> Result<()> {
 
 /// gets the necessary information from user, and writes them to the given
 /// configuration file
-fn get_config_from_user_inputs() -> Result<CliConfig> {
+fn get_config_from_user_inputs() -> Result<Config> {
     // GET USER INPUTS...
     // get reward address
     let reward_address =
@@ -77,7 +77,7 @@ fn get_config_from_user_inputs() -> Result<CliConfig> {
     )?;
 
     // get chain
-    let default_chain = CliChainConfig::Gemini3c;
+    let default_chain = ChainConfig::Gemini3c;
     let chain = get_user_input(
         &format!(
             "Specify the chain to farm (defaults to `{default_chain}`, press enter to use the \
@@ -85,11 +85,12 @@ fn get_config_from_user_inputs() -> Result<CliConfig> {
                          * {:?}: ",` TODO: uncomment this when gemini3d
                          * releases: `ChainConfig::iter().collect::<Vec<_>>()` */
         ),
-        Some(crate::config::CliChainConfig::Gemini3c),
-        CliChainConfig::from_str,
+        Some(crate::config::ChainConfig::Gemini3c),
+        ChainConfig::from_str,
     )?;
 
-    let cache = CacheDescription::new(cache_directory_getter(), bytesize::ByteSize::gb(1))?;
+    // let cache = CacheDescription::new(cache_directory_getter(),
+    // bytesize::ByteSize::gb(1))?;
 
     // let (farmer, node) = match chain {
     //     ChainConfig::Gemini3c => (

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -6,12 +6,12 @@ use color_eyre::eyre::{Context, Result};
 use subspace_sdk::farmer::CacheDescription;
 
 use crate::config::{
-    create_config, ChainConfig, Config, FarmerConfig, NodeConfig, DEFAULT_PLOT_SIZE,
+    create_config, CliChainConfig, CliConfig, CliFarmerConfig, CliNodeConfig, DEFAULT_PLOT_SIZE,
 };
 use crate::utils::{
     cache_directory_getter, get_user_input, node_directory_getter, node_name_parser,
     plot_directory_getter, plot_directory_parser, print_ascii_art, print_version,
-    reward_address_parser, size_parser, yes_or_no_parser,
+    reward_address_parser, size_parser,
 };
 
 /// implementation of the `init` command
@@ -39,7 +39,7 @@ pub(crate) fn init() -> Result<()> {
 
 /// gets the necessary information from user, and writes them to the given
 /// configuration file
-fn get_config_from_user_inputs() -> Result<Config> {
+fn get_config_from_user_inputs() -> Result<CliConfig> {
     // GET USER INPUTS...
     // get reward address
     let reward_address =
@@ -77,7 +77,7 @@ fn get_config_from_user_inputs() -> Result<Config> {
     )?;
 
     // get chain
-    let default_chain = ChainConfig::Gemini3c;
+    let default_chain = CliChainConfig::Gemini3c;
     let chain = get_user_input(
         &format!(
             "Specify the chain to farm (defaults to `{default_chain}`, press enter to use the \
@@ -85,35 +85,25 @@ fn get_config_from_user_inputs() -> Result<Config> {
                          * {:?}: ",` TODO: uncomment this when gemini3d
                          * releases: `ChainConfig::iter().collect::<Vec<_>>()` */
         ),
-        Some(crate::config::ChainConfig::Gemini3c),
-        ChainConfig::from_str,
-    )?;
-
-    let is_executor = get_user_input(
-        "Do you want to be an executor? y/n (defaults to no): ",
-        Some(false),
-        yes_or_no_parser,
+        Some(crate::config::CliChainConfig::Gemini3c),
+        CliChainConfig::from_str,
     )?;
 
     let cache = CacheDescription::new(cache_directory_getter(), bytesize::ByteSize::gb(1))?;
-    let (farmer, node) = match chain {
-        ChainConfig::Gemini3c => (
-            FarmerConfig::gemini_3c(reward_address, plot_directory, plot_size, cache),
-            NodeConfig::gemini_3c(node_directory_getter(), node_name, is_executor),
-        ),
-        ChainConfig::Dev => (
-            FarmerConfig::dev(reward_address, plot_directory, plot_size, cache),
-            NodeConfig::dev(node_directory_getter(), is_executor),
-        ),
-        ChainConfig::DevNet => (
-            FarmerConfig::devnet(reward_address, plot_directory, plot_size, cache),
-            NodeConfig::devnet(node_directory_getter(), node_name, is_executor),
-        ),
-    };
 
-    Ok(Config {
-        chain,
-        farmer,
-        node, // farmer: FarmerConfig::new(),
-    })
+    // let (farmer, node) = match chain {
+    //     ChainConfig::Gemini3c => (
+    //         FarmerConfig::gemini_3c(reward_address, plot_directory,
+    // plot_size, cache),
+    // NodeConfig::gemini_3c(node_directory_getter(), node_name,
+    // is_executor),     ),
+    //     ChainConfig::Dev => (
+    //         FarmerConfig::dev(reward_address, plot_directory, plot_size,
+    // cache),         NodeConfig::dev(node_directory_getter(),
+    // is_executor),     ),
+    //     ChainConfig::DevNet => (
+    //         FarmerConfig::devnet(reward_address, plot_directory, plot_size,
+    // cache),         NodeConfig::devnet(node_directory_getter(), node_name,
+    // is_executor),     ),
+    // };
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -2,16 +2,15 @@ use std::io::Write;
 use std::str::FromStr;
 
 use color_eyre::eyre::{Context, Result};
-// use strum::IntoEnumIterator; // TODO: unlock this when gemini3d releases
-use subspace_sdk::farmer::CacheDescription;
 
+// use strum::IntoEnumIterator; // TODO: unlock this when gemini3d releases
 use crate::config::{
-    create_config, ChainConfig, Config, FarmerConfig, NodeConfig, DEFAULT_PLOT_SIZE,
+    create_config, AdvancedFarmerSettings, AdvancedNodeSettings, ChainConfig, Config, FarmerConfig,
+    NodeConfig, DEFAULT_PLOT_SIZE,
 };
 use crate::utils::{
-    cache_directory_getter, get_user_input, node_directory_getter, node_name_parser,
-    plot_directory_getter, plot_directory_parser, print_ascii_art, print_version,
-    reward_address_parser, size_parser,
+    get_user_input, node_directory_getter, node_name_parser, plot_directory_getter,
+    plot_directory_parser, print_ascii_art, print_version, reward_address_parser, size_parser,
 };
 
 /// implementation of the `init` command
@@ -89,22 +88,17 @@ fn get_config_from_user_inputs() -> Result<Config> {
         ChainConfig::from_str,
     )?;
 
-    // let cache = CacheDescription::new(cache_directory_getter(),
-    // bytesize::ByteSize::gb(1))?;
+    let farmer_config = FarmerConfig {
+        plot_size,
+        plot_directory,
+        reward_address,
+        advanced: AdvancedFarmerSettings::default(),
+    };
+    let node_config = NodeConfig {
+        name: node_name,
+        directory: node_directory_getter(),
+        advanced: AdvancedNodeSettings::default(),
+    };
 
-    // let (farmer, node) = match chain {
-    //     ChainConfig::Gemini3c => (
-    //         FarmerConfig::gemini_3c(reward_address, plot_directory,
-    // plot_size, cache),
-    // NodeConfig::gemini_3c(node_directory_getter(), node_name,
-    // is_executor),     ),
-    //     ChainConfig::Dev => (
-    //         FarmerConfig::dev(reward_address, plot_directory, plot_size,
-    // cache),         NodeConfig::dev(node_directory_getter(),
-    // is_executor),     ),
-    //     ChainConfig::DevNet => (
-    //         FarmerConfig::devnet(reward_address, plot_directory, plot_size,
-    // cache),         NodeConfig::devnet(node_directory_getter(), node_name,
-    // is_executor),     ),
-    // };
+    Ok(Config { farmer: farmer_config, node: node_config, chain })
 }

--- a/src/commands/wipe.rs
+++ b/src/commands/wipe.rs
@@ -1,9 +1,10 @@
 use color_eyre::eyre::Result;
+use subspace_sdk::farmer::CacheDescription;
 use subspace_sdk::{Node, PlotDescription};
 
 use crate::config::parse_config;
 use crate::summary::delete_summary;
-use crate::utils::{node_directory_getter, plot_directory_getter};
+use crate::utils::{cache_directory_getter, node_directory_getter, plot_directory_getter};
 
 /// implementation of the `wipe` command
 ///
@@ -37,7 +38,9 @@ pub(crate) async fn wipe() -> Result<()> {
                 "Skipping wiping plot. Got error while constructing the plot reference: {err}"
             ),
         }
-        let _ = config.farmer.cache.wipe().await;
+        let _ = CacheDescription::new(cache_directory_getter(), config.farmer.advanced.cache_size)?
+            .wipe()
+            .await;
     } else {
         let _ = tokio::fs::remove_dir_all(plot_directory_getter()).await;
     }

--- a/src/commands/wipe.rs
+++ b/src/commands/wipe.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::Result;
+use owo_colors::OwoColorize;
 use subspace_sdk::farmer::CacheDescription;
 use subspace_sdk::{Node, PlotDescription};
 
@@ -15,10 +16,9 @@ pub(crate) async fn wipe() -> Result<()> {
         Err(_) => {
             println!(
                 "could not read your config. Wipe will still continue... \n{}",
-                ansi_term::Style::new().underline().paint(
-                    "However, if you have set a custom location for your plots, you will need to \
-                     manually delete your plots!"
-                )
+                "However, if you have set a custom location for your plots, you will need to \
+                 manually delete your plots!"
+                    .underline()
             );
             None
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ enum Commands {
     Farm {
         #[arg(short, long, action)]
         verbose: bool,
+        #[arg(short, long, action)]
+        executor: bool,
     },
     #[command(about = "wipes the node and farm instance (along with your plots)")]
     Wipe,
@@ -59,8 +61,9 @@ async fn main() -> Result<(), Report> {
         Commands::Init => {
             init().suggestion(support_message())?;
         }
-        Commands::Farm { verbose } => {
-            let (farmer, node, _instance) = farm(verbose).await.suggestion(support_message())?;
+        Commands::Farm { verbose, executor } => {
+            let (farmer, node, _instance) =
+                farm(verbose, executor).await.suggestion(support_message())?;
 
             signal::ctrl_c().await?;
             println!(

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -6,7 +6,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use bytesize::ByteSize;
-use color_eyre::eyre::{Report, Result};
+use color_eyre::eyre::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tokio::fs::{create_dir_all, read_to_string, remove_file, File, OpenOptions};
 use tokio::io::AsyncWriteExt;
@@ -53,7 +53,8 @@ impl Summary {
                     farmed_block_count: 0,
                     user_space_pledged,
                 };
-                let summary_text = toml::to_string(&initialization).map_err(Report::msg)?;
+                let summary_text = toml::to_string(&initialization)
+                    .context("Failed to serialize FarmerSummary")?;
                 OpenOptions::new()
                     .write(true)
                     .truncate(true)
@@ -86,7 +87,7 @@ impl Summary {
             summary.farmed_block_count = count;
         }
 
-        let new_summary = toml::to_string(&summary).map_err(Report::msg)?;
+        let new_summary = toml::to_string(&summary).context("Failed to serialize FarmerSummary")?;
 
         let guard = self.file.lock().await;
         OpenOptions::new()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use bytesize::ByteSize;
 use color_eyre::eyre::{eyre, Report, Result};
+use owo_colors::OwoColorize;
 use subspace_sdk::PublicKey;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
@@ -159,7 +160,7 @@ fn custom_log_dir() -> PathBuf {
 pub(crate) fn support_message() -> String {
     format!(
         "If you think this is a bug, please submit it to our forums: {}",
-        ansi_term::Style::new().underline().paint("https://forum.subspace.network")
+        "https://forum.subspace.network".underline()
     )
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use bytesize::ByteSize;
-use color_eyre::eyre::{eyre, Report, Result};
+use color_eyre::eyre::{eyre, Context, Result};
 use owo_colors::OwoColorize;
 use subspace_sdk::PublicKey;
 use tracing::level_filters::LevelFilter;
@@ -89,7 +89,7 @@ pub(crate) fn node_name_parser(node_name: &str) -> Result<String> {
 
 /// check for a valid SS58 address
 pub(crate) fn reward_address_parser(address: &str) -> Result<PublicKey> {
-    PublicKey::from_str(address).map_err(Report::msg)
+    PublicKey::from_str(address).context("Failed to parse reward address")
 }
 
 /// the provided path should be an existing directory

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -232,7 +232,7 @@ pub(crate) fn install_tracing(is_verbose: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::CliChainConfig;
+    use crate::config::ChainConfig;
 
     #[test]
     fn node_name_checker() {
@@ -256,8 +256,8 @@ mod tests {
 
     #[test]
     fn chain_checker() {
-        assert!(CliChainConfig::from_str("gemini-3c").is_ok());
-        assert!(CliChainConfig::from_str("devv").is_err());
+        assert!(ChainConfig::from_str("gemini-3c").is_ok());
+        assert!(ChainConfig::from_str("devv").is_err());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -113,14 +113,6 @@ pub(crate) fn size_parser(size: &str) -> Result<ByteSize> {
     }
 }
 
-pub(crate) fn yes_or_no_parser(answer: &str) -> Result<bool> {
-    match answer.to_lowercase().as_str() {
-        "y" | "yes" => Ok(true),
-        "n" | "no" => Ok(false),
-        _ => Err(eyre!("could not interpret your answer. Please provide `y` or `n`.")),
-    }
-}
-
 /// generates a plot path from the given path
 pub(crate) fn plot_directory_getter() -> PathBuf {
     data_dir_getter().join("plots")
@@ -240,7 +232,7 @@ pub(crate) fn install_tracing(is_verbose: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ChainConfig;
+    use crate::config::CliChainConfig;
 
     #[test]
     fn node_name_checker() {
@@ -264,8 +256,8 @@ mod tests {
 
     #[test]
     fn chain_checker() {
-        assert!(ChainConfig::from_str("gemini-3c").is_ok());
-        assert!(ChainConfig::from_str("devv").is_err());
+        assert!(CliChainConfig::from_str("gemini-3c").is_ok());
+        assert!(CliChainConfig::from_str("devv").is_err());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -229,6 +229,10 @@ pub(crate) fn install_tracing(is_verbose: bool) {
     }
 }
 
+pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    t == &T::default()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Simplifies the config.
Don't inspect commit by commit, since they do not make sense and I'll squash merge anyway

closes #117 
