### PR TITLE
Update sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9901,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "subspace-sdk"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=e9dd3be8e8e146651f5a235da75d8726597b3af8#e9dd3be8e8e146651f5a235da75d8726597b3af8"
+source = "git+https://github.com/subspace/subspace-sdk?rev=a2c32f4f76ef45ea4fbe8bd8d8bbbdbc0d1daa19#a2c32f4f76ef45ea4fbe8bd8d8bbbdbc0d1daa19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 whoami = "1"
 
-subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "e9dd3be8e8e146651f5a235da75d8726597b3af8" }
+subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "a2c32f4f76ef45ea4fbe8bd8d8bbbdbc0d1daa19" }
 
 # The only triple tested and confirmed as working in `jemallocator` crate is `x86_64-unknown-linux-gnu`
 [target.'cfg(all(target_arch = "x86_64", target_vendor = "unknown", target_os = "linux", target_env = "gnu"))'.dependencies]

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -138,7 +138,9 @@ async fn subscribe_to_node_syncing(node: &Node) -> Result<()> {
             syncing_progress_bar.set_position(current_block);
             syncing_progress_bar.set_length(target_block);
         }
-        syncing_progress_bar.finish_with_message("Initial syncing is completed! Syncing will continue in the background...");
+        syncing_progress_bar.finish_with_message(
+            "Initial syncing is completed! Syncing will continue in the background...",
+        );
     }
     Ok(())
 }

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -138,7 +138,7 @@ async fn subscribe_to_node_syncing(node: &Node) -> Result<()> {
             syncing_progress_bar.set_position(current_block);
             syncing_progress_bar.set_length(target_block);
         }
-        syncing_progress_bar.finish_with_message("Syncing is done!");
+        syncing_progress_bar.finish_with_message("Initial syncing is completed! Syncing will continue in the background...");
     }
     Ok(())
 }


### PR DESCRIPTION
when syncing is completed, now we mention this is only for `initial syncing`, and regular syncing is continuing in the background. Some of the users were confused by it. 