### PR TITLE
Version command

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,8 +9,8 @@ use crate::config::{
     NodeConfig, DEFAULT_PLOT_SIZE,
 };
 use crate::utils::{
-    generate_run_executable_command, get_user_input, node_directory_getter, node_name_parser,
-    plot_directory_getter, plot_directory_parser, print_ascii_art, print_version,
+    get_user_input, node_directory_getter, node_name_parser, plot_directory_getter,
+    plot_directory_parser, print_ascii_art, print_run_executable_command, print_version,
     reward_address_parser, size_parser,
 };
 
@@ -32,7 +32,7 @@ pub(crate) fn init() -> Result<()> {
     println!("Configuration has been generated at {}", config_path.display());
 
     println!("Ready for lift off! Run the follow command to begin:");
-    println!("{}", generate_run_executable_command()?);
+    print_run_executable_command();
 
     Ok(())
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,8 +9,8 @@ use crate::config::{
     NodeConfig, DEFAULT_PLOT_SIZE,
 };
 use crate::utils::{
-    get_user_input, node_directory_getter, node_name_parser, plot_directory_getter,
-    plot_directory_parser, print_ascii_art, print_run_executable_command, print_version,
+    generate_run_executable_command, get_user_input, node_directory_getter, node_name_parser,
+    plot_directory_getter, plot_directory_parser, print_ascii_art, print_version,
     reward_address_parser, size_parser,
 };
 
@@ -32,7 +32,7 @@ pub(crate) fn init() -> Result<()> {
     println!("Configuration has been generated at {}", config_path.display());
 
     println!("Ready for lift off! Run the follow command to begin:");
-    print_run_executable_command();
+    println!("{}", generate_run_executable_command()?);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[command(arg_required_else_help = true)]
 #[command(name = "subspace")]
 #[command(about = "Subspace CLI", long_about = None)]
+#[command(version)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,17 +49,9 @@ pub(crate) fn generate_run_executable_command() -> Result<String> {
     // if current dir is equal to the dir of the exec, just recommend the filename
     // else, recommend the full path
     let exec_name = if current_dir.eq(exec_dir) {
-        format!(
-            "./{}",
-            exec_full_path
-                .file_name()
-                .expect("filename cannot be empty")
-                .to_str()
-                .expect("conversion cannot be empty for filenames")
-                .to_owned()
-        )
+        format!("./{:?}", exec_full_path.file_name().expect("filename cannot be empty"))
     } else {
-        exec_full_path.to_str().expect("conversion cannot be empty for filenames").to_owned()
+        format!("{exec_full_path:?}")
     };
 
     Ok(format!("`{exec_name} farm`"))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,20 +41,10 @@ pub(crate) fn print_version() {
     println!("version: {version}");
 }
 
-pub(crate) fn generate_run_executable_command() -> Result<String> {
-    let exec_full_path = std::env::current_exe()?;
-    let exec_dir = exec_full_path.parent().expect("directory cannot be empty");
-    let current_dir = std::env::current_dir()?;
-
-    // if current dir is equal to the dir of the exec, just recommend the filename
-    // else, recommend the full path
-    let exec_name = if current_dir.eq(exec_dir) {
-        format!("./{:?}", exec_full_path.file_name().expect("filename cannot be empty"))
-    } else {
-        format!("{exec_full_path:?}")
-    };
-
-    Ok(format!("`{exec_name} farm`"))
+pub(crate) fn print_run_executable_command() {
+    let exec_name =
+        std::env::args().next().map(PathBuf::from).expect("First argument always exists");
+    println!("`{exec_name:?} farm`");
 }
 
 /// gets the input from the user for a given `prompt`

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,20 +41,14 @@ pub(crate) fn print_version() {
     println!("version: {version}");
 }
 
-pub(crate) fn print_run_executable_command() {
-    let executable_name = format!(
-        "subspace-cli-{}-{}-v{}-alpha",
-        env::consts::OS,
-        env::consts::ARCH,
-        env!("CARGO_PKG_VERSION")
-    );
-
-    #[cfg(target_os = "windows")]
-    let executable_name = format!("{executable_name}.exe");
-
-    let command = format!("`./{executable_name} farm`");
-
-    println!("{command}");
+pub(crate) fn generate_run_executable_command() -> Result<String> {
+    let executable_name = std::env::current_exe()?
+        .file_name()
+        .expect("filename cannot be empty if `current_exe()` returned ok")
+        .to_str()
+        .expect("osStr to str conversion cannot be empty for filenames")
+        .to_owned();
+    Ok(format!("`./{executable_name} farm`"))
 }
 
 /// gets the input from the user for a given `prompt`

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,7 +45,6 @@ pub(crate) fn generate_run_executable_command() -> Result<String> {
     let exec_full_path = std::env::current_exe()?;
     let exec_dir = exec_full_path.parent().expect("directory cannot be empty");
     let current_dir = std::env::current_dir()?;
-    println!("logging: exec_dir: {} \n current_dir: {}", exec_dir.display(), current_dir.display());
 
     // if current dir is equal to the dir of the exec, just recommend the filename
     // else, recommend the full path

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,13 +42,28 @@ pub(crate) fn print_version() {
 }
 
 pub(crate) fn generate_run_executable_command() -> Result<String> {
-    let executable_name = std::env::current_exe()?
-        .file_name()
-        .expect("filename cannot be empty if `current_exe()` returned ok")
-        .to_str()
-        .expect("osStr to str conversion cannot be empty for filenames")
-        .to_owned();
-    Ok(format!("`./{executable_name} farm`"))
+    let exec_full_path = std::env::current_exe()?;
+    let exec_dir = exec_full_path.parent().expect("directory cannot be empty");
+    let current_dir = std::env::current_dir()?;
+    println!("logging: exec_dir: {} \n current_dir: {}", exec_dir.display(), current_dir.display());
+
+    // if current dir is equal to the dir of the exec, just recommend the filename
+    // else, recommend the full path
+    let exec_name = if current_dir.eq(exec_dir) {
+        format!(
+            "./{}",
+            exec_full_path
+                .file_name()
+                .expect("filename cannot be empty")
+                .to_str()
+                .expect("conversion cannot be empty for filenames")
+                .to_owned()
+        )
+    } else {
+        exec_full_path.to_str().expect("conversion cannot be empty for filenames").to_owned()
+    };
+
+    Ok(format!("`{exec_name} farm`"))
 }
 
 /// gets the input from the user for a given `prompt`


### PR DESCRIPTION
This PR:
- adds `-V` and `--version` flags so users can get the version even if they change the name of the executable
- gets the executable name from `std::env`
- crafts the `subspace-cli farm` command dynamically w.r.t the current directory (if current directory is where the executable is located, only `./subspace-cli farm` is generated. If not, `/path/to/executable/subspace-cli farm` is generated

@ImmaZoni tagging you, so that you can change the docs accordingly when we have a new release

closes #146 