### PR TITLE
Update client name and version, so it will be shown properly in the telemetry

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let output = std::process::Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,8 +88,8 @@ impl NodeConfig {
 
         node = node
             .role(Role::Authority)
-            .impl_version(format!("cli-{}", env!("CARGO_PKG_VERSION")))
-            .impl_name("cli".to_string());
+            .impl_version(format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("GIT_HASH")))
+            .impl_name("Subspace CLI".to_string());
 
         crate::utils::apply_extra_options(&node.configuration(), extra)
             .context("Failed to deserialize node config")?


### PR DESCRIPTION
Telemetry shows `?.?.?` for version if string doesn't match format `major.minor.patch-hash`. So I decided to change to that format.