### PR TITLE
Implement Discord Webhook for Release Notification

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -1,0 +1,67 @@
+# This action is to send a release message to our Discord community. 
+# - It will only trigger when our release workflow completes successfully or be triggered manually.
+# - When triggering this manually you will need to select Branch > Tags > Select the release you want to notify. (Generally the release you just updated from a pre-release.)
+name: Send Release Messages
+
+on:
+  workflow_run:
+    workflows: ["release"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Please run this workflow from the tag of the release you updated'
+        required: true
+        type: boolean
+      notify_community:
+        description: 'I understand that running this workflow will notify the community of my actions'
+        required: true
+        type: boolean
+
+jobs:
+  send_message:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Get release by Tag for manual run
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: manual_release_info
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitSha: ${{ github.sha }}
+          prerelease: false
+      - name: Get release by Tag for release run
+        if: ${{ github.event_name == 'workflow_run' }}
+        id: release_info
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitSha: ${{ github.event.workflow_run.head_sha }}
+          prerelease: false
+          latest: true
+      - name: Send Discord Message
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' && github.event.workflow_run.head_branch ==  steps.release_info.outputs.tag_name}}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: |
+            ${{ steps.release_info.outputs.tag_name || steps.manual_release_info.outputs.tag_name }} of ${{ github.repository }} has been released!
+            
+            *Release Name:**
+            ```
+            ${{ steps.release_info.outputs.name || steps.manual_release_info.outputs.name }}
+            ```
+
+            *Release Description:**
+            ```
+            ${{ steps.release_info.outputs.body || steps.manual_release_info.outputs.body }}
+            ```
+            Read more at: ${{ steps.release_info.outputs.html_url || steps.manual_release_info.outputs.html_url }}
+
+            You can also update by visiting our docs at:
+            https://docs.subspace.network/docs/protocol/cli


### PR DESCRIPTION
# Overview

This GitHub Action will notify our Discord community using a provided webhook URL (provided as a GitHub Secret). We are using a custom action instead of the native GitHub webhook because of the lack of customization in messaging and lack of control regarding the notification of a pre-release or latest release. The default webhook will notify of all releases, regardless of the release type.

# Solution

This action works with the following logic:

It is triggered under two circumstances:

- The successful completion of our `release` workflow.
- A manual trigger.

We will walk through the pathway for each trigger separately for clarity.

## On completion of `release` workflow

This pathway assumes the release being created is being marked as latest and is not a pre-release.

1. The `release` workflow completes with no errors, sending the `success` event with the trigger.
2. We then get the branch (tag) that was used with the triggering workflow and pull the latest release information.
3. We verify that the branch initiating the workflow is, in fact, the same branch that is the latest release (this is to verify it's NOT a pre-release or draft).
4. We then send a notification to Discord with the latest release information in a nice, readable format. See examples below.

## On manual trigger

This pathway is for when a developer is upgrading a pre-release to a release.

1. The developer/admin goes to GitHub, updates a pre-release to a release.
2. The dev/admin goes to Actions and triggers the Send Release Message workflow.
3. They will see a popup and select the tag of the release they just updated.
4. We then pull the latest release of the provided tag and send a notification with the latest release information in a nice, readable format. See examples below.

## Notes on Manual Trigger

Unfortunately, GitHub events don't quite trigger reliably enough when you simply change the checkbox on the release from pre-release to release. This is why we require the developer to run this manually if it is a pre-release being promoted to a release.

## Implementation

- [ ] -  PR Approval
- [ ] - Add DISCORD_WEBHOOK github secret (Available in vault)

## Example
```

v1.0.12 of Subspace/subspace-cli has been released!
            
*Release Name:**
v0.1.12
         
**Release Description:**

# What's New:
  - fix a bug where farmer silent exits in verbose mode -> 🐞 [Bug]: Farmer quietly exits #152
  - added --farmer and --node flag for wipe command. Now, users can wipe farmer and node independently -> 🎁 [Feature Request]: Add flags for wiping, specifically node or farmer #130
  - v2 and v3 executables for windows
  - fixed a bug on extra options for overriding substrate flags
  There are two versions:

  - x86-64-v3: for newer processors since ~2015
  - x86-64-v2: for older processors since ~2009 and some old VMs
    
Read more at: https://github.com/subspace/subspace-cli/releases/tag/v0.1.12
  
  You can also update by visiting our docs at:
            https://docs.subspace.network/docs/protocol/cli

```
