### PR TITLE
implement node and plot improvements

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -60,7 +60,8 @@ fn get_config_from_user_inputs() -> Result<Config> {
     let default_plot_loc = plot_directory_getter();
     let plot_directory = get_user_input(
         &format!(
-            "Specify a plot location (press enter to use the default: `{default_plot_loc:?}`): ",
+            "Specify a path for storing plot files (press enter to use the default: \
+             `{default_plot_loc:?}`): ",
         ),
         Some(default_plot_loc),
         directory_parser,
@@ -69,7 +70,8 @@ fn get_config_from_user_inputs() -> Result<Config> {
     let default_node_loc = node_directory_getter();
     let node_directory = get_user_input(
         &format!(
-            "Specify a node location (press enter to use the default: `{default_node_loc:?}`): ",
+            "Specify a path for storing node files (press enter to use the default: \
+             `{default_node_loc:?}`): ",
         ),
         Some(default_node_loc),
         directory_parser,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,8 +9,8 @@ use crate::config::{
     NodeConfig, DEFAULT_PLOT_SIZE,
 };
 use crate::utils::{
-    get_user_input, node_directory_getter, node_name_parser, plot_directory_getter,
-    plot_directory_parser, print_ascii_art, print_run_executable_command, print_version,
+    directory_parser, get_user_input, node_directory_getter, node_name_parser,
+    plot_directory_getter, print_ascii_art, print_run_executable_command, print_version,
     reward_address_parser, size_parser,
 };
 
@@ -63,7 +63,16 @@ fn get_config_from_user_inputs() -> Result<Config> {
             "Specify a plot location (press enter to use the default: `{default_plot_loc:?}`): ",
         ),
         Some(default_plot_loc),
-        plot_directory_parser,
+        directory_parser,
+    )?;
+
+    let default_node_loc = node_directory_getter();
+    let node_directory = get_user_input(
+        &format!(
+            "Specify a node location (press enter to use the default: `{default_node_loc:?}`): ",
+        ),
+        Some(default_node_loc),
+        directory_parser,
     )?;
 
     // get plot size
@@ -96,7 +105,7 @@ fn get_config_from_user_inputs() -> Result<Config> {
     };
     let node_config = NodeConfig {
         name: node_name,
-        directory: node_directory_getter(),
+        directory: node_directory,
         advanced: AdvancedNodeSettings::default(),
     };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 
 use crate::config::ChainConfig;
 use crate::utils::{
-    apply_extra_options, cache_directory_getter, custom_log_dir, node_directory_getter,
-    node_name_parser, plot_directory_getter, plot_directory_parser, reward_address_parser,
+    apply_extra_options, cache_directory_getter, custom_log_dir, directory_parser,
+    node_directory_getter, node_name_parser, plot_directory_getter, reward_address_parser,
     size_parser, yes_or_no_parser,
 };
 
@@ -45,10 +45,8 @@ fn yes_no_checker() {
 }
 
 #[test]
-fn plot_directory_checker() {
-    assert!(plot_directory_parser("some-weird-location-that-does-not-exist").is_err());
-    assert!(plot_directory_parser("some/weird/location/that/does/not/exist").is_err());
-    assert!(plot_directory_parser("./").is_ok());
+fn directory_checker() {
+    assert!(directory_parser("./").is_ok());
 }
 
 #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -100,11 +100,18 @@ pub(crate) fn reward_address_parser(address: &str) -> Result<PublicKey> {
 }
 
 /// the provided path should be an existing directory
-pub(crate) fn plot_directory_parser(location: &str) -> Result<PathBuf> {
+pub(crate) fn directory_parser(location: &str) -> Result<PathBuf> {
     let path = Path::new(location).to_owned();
     if path.is_dir() {
         Ok(path)
     } else {
+        // prompt the user for creation of the given path
+        let prompt = "The given path does not exist. Do you want to create it? (y/n): ";
+        let permission = get_user_input(prompt, None, yes_or_no_parser).context("prompt failed")?;
+        if permission {
+            create_dir_all(&path)?;
+            return Ok(path);
+        }
         Err(eyre!("supplied directory does not exist! Please enter a valid path."))
     }
 }


### PR DESCRIPTION
Closes #174 and closes #173 

This PR:
- makes node directory customizable in `init` step
- when user supplies a path for `node` or `plot` directory, and if that path is not created yet, the program now prompts the user for creation of this directory