### PR TITLE
fix clock skew by making console subscriber optional via flag

### DIFF
--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -35,8 +35,8 @@ type MaybeHandles = Option<(JoinHandle<Result<()>>, JoinHandle<Result<()>>)>;
 /// lastly, depending on the verbosity, it subscribes to plotting progress and
 /// new solutions
 #[instrument]
-pub(crate) async fn farm(is_verbose: bool, executor: bool) -> Result<()> {
-    install_tracing(is_verbose);
+pub(crate) async fn farm(is_verbose: bool, executor: bool, debug: bool) -> Result<()> {
+    install_tracing(is_verbose, debug);
     color_eyre::install()
         .context("color eyre installment failed, it should have been the first one")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ enum Commands {
         verbose: bool,
         #[arg(short, long, action)]
         executor: bool,
-        #[arg(short, long, action)]
+        #[arg(long, action)]
         debug: bool,
     },
     #[command(about = "wipes the node and farm instance (along with your plots)")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,8 @@ enum Commands {
         verbose: bool,
         #[arg(short, long, action)]
         executor: bool,
+        #[arg(short, long, action)]
+        debug: bool,
     },
     #[command(about = "wipes the node and farm instance (along with your plots)")]
     Wipe {
@@ -88,8 +90,8 @@ async fn main() -> Result<(), Report> {
         Some(Commands::Init) => {
             init().suggestion(support_message())?;
         }
-        Some(Commands::Farm { verbose, executor }) => {
-            farm(verbose, executor).await.suggestion(support_message())?;
+        Some(Commands::Farm { verbose, executor, debug }) => {
+            farm(verbose, executor, debug).await.suggestion(support_message())?;
         }
         Some(Commands::Wipe { farmer, node }) => {
             wipe_config(farmer, node).await.suggestion(support_message())?;
@@ -165,7 +167,7 @@ async fn arrow_key_mode() -> Result<(), Report> {
             let executor =
                 get_user_input(prompt, None, yes_or_no_parser).context("prompt failed")?;
 
-            farm(verbose, executor).await.suggestion(support_message())?;
+            farm(verbose, executor, false).await.suggestion(support_message())?;
         }
         2 => {
             wipe_config(false, false).await.suggestion(support_message())?;
@@ -214,7 +216,7 @@ fn print_options(
 impl std::fmt::Display for Commands {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
-            Commands::Farm { verbose: _, executor: _ } => write!(f, "farm"),
+            Commands::Farm { verbose: _, executor: _, debug: _ } => write!(f, "farm"),
             Commands::Wipe { farmer: _, node: _ } => write!(f, "wipe"),
             Commands::Info => write!(f, "info"),
             Commands::Init => write!(f, "init"),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -218,7 +218,7 @@ pub(crate) fn raise_fd_limit() {
 }
 
 /// install a logger for the application
-pub(crate) fn install_tracing(is_verbose: bool) {
+pub(crate) fn install_tracing(is_verbose: bool, enable_console_subscriber: bool) {
     let log_dir = custom_log_dir();
     let _ = create_dir_all(&log_dir);
 
@@ -239,7 +239,14 @@ pub(crate) fn install_tracing(is_verbose: bool) {
 
     // start logger, after we acquire the bundle identifier
     #[cfg(tokio_unstable)]
-    let tracing_layer = tracing_subscriber::registry().with(console_subscriber::spawn());
+    {
+        // TODO: get rid of this if-else when this issue is resolved: https://github.com/tokio-rs/console/issues/299
+        if enable_console_subscriber {
+            let tracing_layer = tracing_subscriber::registry().with(console_subscriber::spawn());
+        } else {
+            let tracing_layer = tracing_subscriber::registry();
+        }
+    }
 
     #[cfg(not(tokio_unstable))]
     let tracing_layer = tracing_subscriber::registry();


### PR DESCRIPTION
The clock skew issue is indeed a bug in the tokio console subscriber (https://github.com/tokio-rs/console/issues/299). 
As a workaround, I have implemented the following solution:
- do not completely disable tokio console subscriber
- enable it only when user supplies `--debug` flag to `farm` command
- for the TUI (selecting commands with arrow keys), there is no way to enable tokio-console-subscriber. The reasons are as the following: 
    - to enable this, I had to ask another question on top of `executor` and `verbosity`, and I think at this point it degrades the UX
    - also, if the user needs to enable the debug, they can via running `farm --debug`
    - default `debug` value being `false` for the TUI makes more sense

lastly, there is no short version for the command, so `-d` won't work. This is a deliberate choice