### PR TITLE
Summary bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "core-eth-relay-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1590,6 +1590,7 @@ dependencies = [
  "pallet-feeds",
  "pallet-messenger",
  "pallet-sudo",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
@@ -1618,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "core-evm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1632,7 +1633,6 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-base-fee",
- "pallet-dynamic-fee",
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-chain-id",
@@ -1641,6 +1641,7 @@ dependencies = [
  "pallet-evm-precompile-simple",
  "pallet-messenger",
  "pallet-sudo",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-transporter",
@@ -1683,7 +1684,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 [[package]]
 name = "core-payments-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -1878,7 +1879,7 @@ checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2476,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -2493,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "domain-runtime-primitives",
  "parity-scale-codec",
@@ -2510,6 +2511,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "subspace-core-primitives",
+ "subspace-runtime-primitives",
  "subspace-wasm-tools",
  "system-runtime-primitives",
  "tracing",
@@ -2518,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "futures",
@@ -2535,7 +2537,7 @@ dependencies = [
 [[package]]
 name = "domain-client-executor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "crossbeam",
  "domain-block-builder",
@@ -2578,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "domain-client-executor-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2596,7 +2598,7 @@ dependencies = [
 [[package]]
 name = "domain-client-message-relayer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-channel",
  "cross-domain-message-gossip",
@@ -2623,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "domain-eth-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "clap",
  "domain-runtime-primitives",
@@ -2656,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2673,19 +2675,21 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
+ "scale-info",
  "sp-api",
  "sp-core 7.0.0",
  "sp-runtime",
  "sp-std 5.0.0",
+ "subspace-runtime-primitives",
 ]
 
 [[package]]
 name = "domain-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "clap",
@@ -3454,16 +3458,6 @@ dependencies = [
  "sp-core 7.0.0",
  "sp-runtime",
  "sp-std 5.0.0",
-]
-
-[[package]]
-name = "fp-dynamic-fee"
-version = "1.0.0"
-source = "git+https://github.com/subspace/frontier/?rev=e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b#e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b"
-dependencies = [
- "async-trait",
- "sp-core 7.0.0",
- "sp-inherents",
 ]
 
 [[package]]
@@ -6714,7 +6708,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6825,7 +6819,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6846,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6857,22 +6851,6 @@ dependencies = [
  "sp-core 7.0.0",
  "sp-domains",
  "sp-runtime",
- "sp-std 5.0.0",
-]
-
-[[package]]
-name = "pallet-dynamic-fee"
-version = "4.0.0-dev"
-source = "git+https://github.com/subspace/frontier/?rev=e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b#e60f3f8617cabd3473bd5e197b7c0c1991fbcd9b"
-dependencies = [
- "fp-dynamic-fee",
- "fp-evm",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core 7.0.0",
- "sp-inherents",
  "sp-std 5.0.0",
 ]
 
@@ -6965,7 +6943,7 @@ dependencies = [
 [[package]]
 name = "pallet-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6983,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6999,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -7019,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7037,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7052,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7067,7 +7045,7 @@ dependencies = [
 [[package]]
 name = "pallet-receipts"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7083,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7096,7 +7074,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7108,7 +7086,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7164,7 +7142,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7220,8 +7198,9 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
+ "domain-runtime-primitives",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -8686,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8724,7 +8703,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8765,7 +8744,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9316,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -10217,7 +10196,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "log",
@@ -10402,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10414,7 +10393,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "blake2",
  "merlin",
@@ -10440,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "sp-executor-registry"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
  "sp-domains",
@@ -10550,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "frame-support",
  "hash-db 0.16.0",
@@ -10567,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "sp-api",
  "sp-std 5.0.0",
@@ -10598,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "sp-receipts"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11114,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -11169,7 +11148,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "ark-bls12-381",
  "ark-ff",
@@ -11197,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "blst_from_scratch",
  "kzg",
@@ -11207,7 +11186,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11256,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "backoff",
@@ -11282,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -11308,7 +11287,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -11345,7 +11324,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "hex",
  "serde",
@@ -11357,7 +11336,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11411,7 +11390,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -11424,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "subspace-sdk"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=faf31d4e8079c45f4512ebe77aa77bfb27326b01#faf31d4e8079c45f4512ebe77aa77bfb27326b01"
+source = "git+https://github.com/subspace/subspace-sdk?rev=7f4a1d6f094d761adadbf400056390ebe476b109#7f4a1d6f094d761adadbf400056390ebe476b109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11447,6 +11426,7 @@ dependencies = [
  "domain-service",
  "either",
  "event-listener-primitives",
+ "fp-evm",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -11528,7 +11508,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -11596,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "merlin",
  "schnorrkel",
@@ -11606,7 +11586,7 @@ dependencies = [
 [[package]]
 name = "subspace-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11633,7 +11613,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -11650,7 +11630,7 @@ dependencies = [
 [[package]]
 name = "subspace-wasm-tools"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "sc-executor-common",
  "sp-domains",
@@ -11804,7 +11784,7 @@ dependencies = [
 [[package]]
 name = "system-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "core-payments-domain-runtime",
  "domain-pallet-executive",
@@ -11848,7 +11828,7 @@ dependencies = [
 [[package]]
 name = "system-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=663c82a8b8f63bcee12554f1107fdd1f53a8ad2f#663c82a8b8f63bcee12554f1107fdd1f53a8ad2f"
+source = "git+https://github.com/subspace/subspace?rev=43777a701ee1c61d2a3d1373ede890cbb3b161c9#43777a701ee1c61d2a3d1373ede890cbb3b161c9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11126,7 +11126,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 whoami = "1"
 zeroize = "1.6.0"
 
-subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "faf31d4e8079c45f4512ebe77aa77bfb27326b01" }
+subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "7f4a1d6f094d761adadbf400056390ebe476b109" }
 
 
 [dev-dependencies]

--- a/src/commands/farm.rs
+++ b/src/commands/farm.rs
@@ -270,14 +270,14 @@ async fn subscribe_to_solutions(
     // necessary for spacing
     println!();
 
-    let Summary { last_processed_block_num: last_block_num, .. } =
+    let Summary { last_processed_block_num, .. } =
         summary_file.parse().await.context("parsing the summary failed")?;
 
     // first, process the stream in a parallelized fashion,
     // after that, there will be new blocks arrived
     // process these new blocks sequentially
     process_block_stream(
-        last_block_num,
+        last_processed_block_num,
         node.clone(),
         blocks_pruning,
         summary_file.clone(),
@@ -298,14 +298,14 @@ async fn subscribe_to_solutions(
             print!(
                 "\rYou have earned: {total_rewards} SSC(s), farmed {authored_count} block(s), and \
                  voted on {vote_count} block(s)! This data is derived from the first \
-                 {last_processed_block_num} blocks.\n",
+                 {last_processed_block_num} blocks.",
             );
             // flush the stdout to make sure values are printed
             std::io::stdout().flush().expect("Failed to flush stdout");
 
             // now, process the blocks without paralellization
             process_block_stream(
-                last_block_num,
+                last_processed_block_num,
                 node.clone(),
                 blocks_pruning,
                 summary_file.clone(),

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -169,11 +169,11 @@ impl SummaryFile {
             .write_all(serialized_summary.as_bytes())
             .await
             .context("couldn't write to summary file")?;
+        guard.flush().await.context("flushing failed for summary file")?;
         guard
             .seek(std::io::SeekFrom::Start(0))
             .await
             .context("couldn't seek to the beginning of the summary file")?;
-        guard.flush().await.context("flushing failed for summary file")?;
 
         Ok(summary)
     }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -14,7 +14,7 @@ use subspace_sdk::node::BlockNumber;
 use subspace_sdk::ByteSize;
 use tokio::fs::{create_dir_all, File, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, MutexGuard};
 use tracing::instrument;
 
 // TODO: delete this when https://github.com/toml-rs/toml/issues/540 is solved
@@ -110,24 +110,10 @@ impl SummaryFile {
         Ok(SummaryFile { inner: Arc::new(Mutex::new(summary_file)) })
     }
 
-    /// parses the summary file and returns [`Summary`]
+    /// Parses the summary file and returns [`Summary`]
     #[instrument]
     pub(crate) async fn parse(&self) -> Result<Summary> {
-        let mut guard = self.inner.lock().await;
-        let mut contents = String::new();
-
-        guard
-            .read_to_string(&mut contents)
-            .await
-            .context("couldn't read the contents of the summary file")?;
-        let summary: Summary =
-            toml::from_str(&contents).context("couldn't serialize the summary content")?;
-
-        guard
-            .seek(std::io::SeekFrom::Start(0))
-            .await
-            .context("couldn't seek to the beginning of the summary file")?;
-
+        let (summary, _) = self.read_and_deserialize().await?;
         Ok(summary)
     }
 
@@ -147,7 +133,7 @@ impl SummaryFile {
             new_parsed_blocks,
         }: SummaryUpdateFields,
     ) -> Result<Summary> {
-        let mut summary = self.parse().await.context("couldn't parse summary in update method")?;
+        let (mut summary, mut guard) = self.read_and_deserialize().await?;
 
         if is_plotting_finished {
             summary.initial_plotting_finished = true;
@@ -163,7 +149,7 @@ impl SummaryFile {
 
         let serialized_summary =
             toml::to_string(&summary).context("Failed to serialize Summary")?;
-        let mut guard = self.inner.lock().await;
+
         guard.set_len(0).await.context("couldn't truncate the summary file")?;
         guard
             .write_all(serialized_summary.as_bytes())
@@ -176,6 +162,28 @@ impl SummaryFile {
             .context("couldn't seek to the beginning of the summary file")?;
 
         Ok(summary)
+    }
+
+    /// Reads the file, serializes it into `Summary` and seeks to the beginning
+    /// of the file
+    #[instrument]
+    async fn read_and_deserialize(&self) -> Result<(Summary, MutexGuard<'_, File>)> {
+        let mut guard = self.inner.lock().await;
+        let mut contents = String::new();
+
+        guard
+            .read_to_string(&mut contents)
+            .await
+            .context("couldn't read the contents of the summary file")?;
+        let summary: Summary =
+            toml::from_str(&contents).context("couldn't serialize the summary content")?;
+
+        guard
+            .seek(std::io::SeekFrom::Start(0))
+            .await
+            .context("couldn't seek to the beginning of the summary file")?;
+
+        Ok((summary, guard))
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,7 @@ use crate::utils::{
 async fn update_summary_file_randomly(summary_file: SummaryFile) {
     let mut rng = SmallRng::from_entropy();
 
-    for _ in 0..5 {
+    for _ in 0..10 {
         let update_fields = SummaryUpdateFields {
             is_plotting_finished: false,
             new_authored_count: rng.gen_range(1..10),


### PR DESCRIPTION
Previously,`update()` method for `Summary`:
1. acquire lock for parsing the summary
2. release that lock
3. acquire a new lock for writing to summary
4. write, then release the lock

Also, it was moving the cursor (seeking) to the beginning of the file, and then flushes. 

I have fixed those 2 things in this PR. 

Also, yanking the version, since I'll publish a new version (we have key generation on CLI right now, and this small bug fix)

Closes #202 

Note: will squash commit
