### PR TITLE
change v3 to skylake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
-            suffix: ubuntu-x86_64-v3-${{ github.ref_name }}
-            rustflags: "-C target-cpu=x86-64-v3"
+            suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
+            rustflags: "-C target-cpu=skylake"
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             production_target: target/aarch64-unknown-linux-gnu/aarch64linux
@@ -50,8 +50,8 @@ jobs:
           - os: windows-2022
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
-            suffix: windows-x86_64-v3-${{ github.ref_name }}
-            rustflags: "-C target-cpu=x86-64-v3"
+            suffix: windows-x86_64-skylake-${{ github.ref_name }}
+            rustflags: "-C target-cpu=skylake"
 
     runs-on: ${{ matrix.build.os }}
 


### PR DESCRIPTION
Release workflow is no longer working for aarch linux. 
This will hopefully fix it