### PR TITLE
Self-hosted GitHub Actions runners

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,10 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-22.04
-          - macos-12
-          - windows-2022
+        os: ${{ fromJson(github.repository_owner == 'subspace' && '[["self-hosted", "ubuntu-20.04-x86-64", "Linux"], ["self-hosted", "macos-12-arm64", "macOS"], ["self-hosted", "windows-server-2022-x86-64", "Windows"]]' || '["ubuntu-20.04", "macos-12", "windows-2022"]') }}
         run-all:
           - ${{ inputs.test-macos-and-windows == true || github.ref == 'refs/heads/main' }}
         exclude: # exclude macos-12 and windows-2022 when the condition is false
@@ -54,17 +51,18 @@ jobs:
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: runner.os == 'macOS'
+        if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+        if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-latest", "windows-2022"]'), runner.os)
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        if: runner.os == 'Windows'
+        if: contains(fromJSON('["windows-latest", "windows-2022"]'), runner.os)
 
       - name: cargo fmt
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -54,7 +54,7 @@ jobs:
         if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-latest", "windows-2022"]'), runner.os)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,12 +51,12 @@ jobs:
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: contains(fromJSON('["macOS"]'), runner.os)
+        if: runner.os == 'macOS'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
+        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
-          version: "23.3"
+          version: "23.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,7 +32,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '[["self-hosted", "ubuntu-22.04-x86-64", "Linux"], ["self-hosted", "macos-12-arm64", "macOS"], ["self-hosted", "windows-server-2022-x86-64", "Windows"]]' || '["ubuntu-22.04", "macos-12", "windows-2022"]') }}
+        os:
+          - ubuntu-22.04
+          - macos-12
+          - windows-2022
         run-all:
           - ${{ inputs.test-macos-and-windows == true || github.ref == 'refs/heads/main' }}
         exclude: # exclude macos-12 and windows-2022 when the condition is false
@@ -40,40 +43,28 @@ jobs:
             os: macos-12
           - run-all: false
             os: windows-2022
-          - run-all: false
-            os: macOS
-          - run-all: false
-            os: Windows
 
     runs-on: ${{ matrix.os }}
     steps:
       - name: git checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
-      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support, we also install clang on Windows
+      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: runner.os == 'macOS' || runner.os == 'Windows'
+        if: runner.os == 'macOS'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: runner.os == 'Linux' || runner.os == 'macOS'
 
-      - name: Install Protoc Windows
-        run: |
-          Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-win64.zip -Outfile protoc-23.3-win64.zip
-          Expand-Archive -Force .\protoc-23.3-win64.zip -DestinationPath C:\protoc-23.3 
+      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
+      - name: Remove msys64
+        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
         if: runner.os == 'Windows'
-
-      - name: Install nightly
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly-2023-05-16
-            components: rustfmt, clippy, rust-src,rust-std
 
       - name: cargo fmt
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(github.repository_owner == 'subspace' && '[["self-hosted", "ubuntu-20.04-x86-64", "Linux"], ["self-hosted", "macos-12-arm64", "macOS"], ["self-hosted", "windows-server-2022-x86-64", "Windows"]]' || '["ubuntu-20.04", "macos-12", "windows-2022"]') }}
+        os: ${{ fromJson(github.repository_owner == 'subspace' && '[["self-hosted", "ubuntu-20.04-x86-64"], ["self-hosted", "macos-12-arm64"], ["self-hosted", "windows-server-2022-x86-64"]]' || '["ubuntu-20.04", "macos-12", "windows-2022"]') }}
         run-all:
           - ${{ inputs.test-macos-and-windows == true || github.ref == 'refs/heads/main' }}
         exclude: # exclude macos-12 and windows-2022 when the condition is false
@@ -51,18 +51,20 @@ jobs:
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
+        if: contains(fromJSON('["macOS", "Windows"]'), runner.os)
 
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-latest", "windows-2022"]'), runner.os)
+        if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
+        continue-on-error: true
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        if: contains(fromJSON('["windows-latest", "windows-2022"]'), runner.os)
+        if: runner.os == 'Windows'
+        continue-on-error: true
 
       - name: cargo fmt
         uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # @v1.0.1

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -60,6 +60,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS"]'), runner.os)
 
+      # Workaround to resolve https://github.com/arduino/setup-protoc/issues/86
       - name: Install Protoc Windows
         run: |
           Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip -Outfile protoc-23.4-win64.zip

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -56,15 +56,14 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
-          version: "23.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS"]'), runner.os)
 
       # Workaround to resolve https://github.com/arduino/setup-protoc/issues/86
-      - name: Install Protoc Windows
-        run: |
-          Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip -Outfile protoc-23.4-win64.zip
-          Expand-Archive -Force .\protoc-23.4-win64.zip -DestinationPath C:\protoc-23.4 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: runner.os == 'Windows'
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -54,7 +54,7 @@ jobs:
         if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-latest", "windows-2022"]'), runner.os)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -58,7 +58,13 @@ jobs:
         with:
           version: "23.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
+        if: contains(fromJSON('["Linux", "macOS"]'), runner.os)
+
+      - name: Install Protoc Windows
+        run: |
+          Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip -Outfile protoc-23.4-win64.zip
+          Expand-Archive -Force .\protoc-23.4-win64.zip -DestinationPath C:\protoc-23.4 
+        if: runner.os == 'Windows'
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -51,14 +51,13 @@ jobs:
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: contains(fromJSON('["macOS", "Windows"]'), runner.os)
+        if: contains(fromJSON('["macOS"]'), runner.os)
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
-        continue-on-error: true
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:
+          version: "23.3"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,4 +171,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["executables/*"]'
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: ${{ github.github.repository_owner == 'subspace' && github.event_name == 'push' && github.ref_type == 'tag' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,9 @@ jobs:
         if: contains(fromJSON('["macOS"]'), runner.os)
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
+        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:
+          version: "23.3"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,19 +69,19 @@ jobs:
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: contains(fromJSON('["macOS"]'), runner.os)
+        if: runner.os == 'macOS'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
+        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
-          version: "23.3"
+          version: "23.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        if: runner.os == "Windows"
+        if: runner.os == 'Windows'
         continue-on-error: true
 
       - name: Linux AArch64 cross-compile packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,37 +17,37 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-20.04"]') }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-20.04") }}
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-20.04"]') }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-20.04") }}
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
             rustflags: "-C target-cpu=skylake"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-20.04"]') }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-20.04") }}
             target: aarch64-unknown-linux-gnu
             production_target: target/aarch64-unknown-linux-gnu/aarch64linux
             suffix: ubuntu-aarch64-${{ github.ref_name }}
             rustflags: "-C linker=aarch64-linux-gnu-gcc"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64", "macOS"]' || '["macos-12"]') }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64"]' || "macos-12") }}
             target: x86_64-apple-darwin
             production_target: target/x86_64-apple-darwin/production
             suffix: macos-x86_64-${{ github.ref_name }}
             rustflags: ""
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64", "macOS"]' || '["macos-12"]') }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64"]' || "macos-12") }}
             target: aarch64-apple-darwin
             production_target: target/aarch64-apple-darwin/production
             suffix: macos-aarch64-${{ github.ref_name }}
             rustflags: ""
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64", "Windows"]' || '["windows-2022"]') }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || "windows-2022") }}
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64", "Windows"]' || '["windows-2022"]') }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || "windows-2022") }}
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-skylake-${{ github.ref_name }}
@@ -64,23 +64,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
-      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support, we also install clang on Windows
+      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
+        if: contains(fromJSON('["macOS", "Windows"]'), runner.os)
 
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-2022"]'), runner.os)
+        if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
+        continue-on-error: true
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        if: contains(fromJSON('["windows-latest", "windows-2022"]'), runner.os)
+        if: runner.os == "Windows"
+        continue-on-error: true
 
       - name: Linux AArch64 cross-compile packages
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-arm64-cross
@@ -123,7 +125,7 @@ jobs:
           echo "Done!"
         # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
         continue-on-error: ${{ github.github.repository_owner != 'subspace' || github.event_name != 'push' || github.ref_type != 'tag' }}
-        if: runner.os == 'macOS' || runner.os == 'macos-12'
+        if: runner.os == 'macOS'
 
       - name: Sign Application (Windows)
         uses: skymatic/code-sign-action@cfcc1c15b32938bab6dea25192045b6d2989e4d0 # @v1.1.0
@@ -134,13 +136,13 @@ jobs:
           folder: "${{ matrix.build.production_target }}"
         # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
         continue-on-error: ${{ github.github.repository_owner != 'subspace' || github.event_name != 'push' || github.ref_type != 'tag' }}
-        if: runner.os == 'Windows' || runner.os == 'windows-2022'
+        if: runner.os == 'Windows'
 
       - name: Prepare executables for uploading (Ubuntu)
         run: |
           mkdir executables
           mv ${{ matrix.build.production_target }}/subspace-cli executables/subspace-cli-${{ matrix.build.suffix }}
-        if: runner.os == 'Linux' || runner.os == 'ubuntu-20.04'
+        if: runner.os == 'Linux'
 
       - name: Prepare executables for uploading (macOS)
         run: |
@@ -149,13 +151,13 @@ jobs:
           # Zip it so that signature is not lost
           ditto -c -k --rsrc executables/subspace-cli-${{ matrix.build.suffix }} executables/subspace-cli-${{ matrix.build.suffix }}.zip
           rm executables/subspace-cli-${{ matrix.build.suffix }}
-        if: runner.os == 'macOS' || runner.os == 'macos-12'
+        if: runner.os == 'macOS'
 
       - name: Prepare executables for uploading (Windows)
         run: |
           mkdir executables
           move ${{ matrix.build.production_target }}/subspace-cli.exe executables/subspace-cli-${{ matrix.build.suffix }}.exe
-        if: runner.os == 'Windows' || runner.os == 'windows-2022'
+        if: runner.os == 'Windows'
 
       - name: Upload executable to artifacts
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1
@@ -171,4 +173,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["executables/*"]'
-        if: ${{ github.github.repository_owner == 'subspace' && github.event_name == 'push' && github.ref_type == 'tag' }}
+        if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,13 @@ jobs:
         with:
           version: "23.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
+        if: contains(fromJSON('["Linux", "macOS"]'), runner.os)
+
+      - name: Install Protoc Windows
+        run: |
+          Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip -Outfile protoc-23.4-win64.zip
+          Expand-Archive -Force .\protoc-23.4-win64.zip -DestinationPath C:\protoc-23.4 
+        if: runner.os == 'Windows'
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS"]'), runner.os)
 
+      # Workaround to resolve https://github.com/arduino/setup-protoc/issues/86
       - name: Install Protoc Windows
         run: |
           Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip -Outfile protoc-23.4-win64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-2022"]'), runner.os)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,13 @@ jobs:
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: contains(fromJSON('["macOS", "Windows"]'), runner.os)
+        if: contains(fromJSON('["macOS"]'), runner.os)
 
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS", "Windows"]'), runner.os)
-        continue-on-error: true
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,15 +74,14 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
         with:
-          version: "23.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "macOS"]'), runner.os)
 
       # Workaround to resolve https://github.com/arduino/setup-protoc/issues/86
-      - name: Install Protoc Windows
-        run: |
-          Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-win64.zip -Outfile protoc-23.4-win64.zip
-          Expand-Archive -Force .\protoc-23.4-win64.zip -DestinationPath C:\protoc-23.4 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: runner.os == 'Windows'
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,37 +17,37 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-20.04") }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-20.04') }}
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-20.04") }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-20.04') }}
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
             rustflags: "-C target-cpu=skylake"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-20.04") }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-20.04') }}
             target: aarch64-unknown-linux-gnu
             production_target: target/aarch64-unknown-linux-gnu/aarch64linux
             suffix: ubuntu-aarch64-${{ github.ref_name }}
             rustflags: "-C linker=aarch64-linux-gnu-gcc"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64"]' || "macos-12") }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64"]' || 'macos-12') }}
             target: x86_64-apple-darwin
             production_target: target/x86_64-apple-darwin/production
             suffix: macos-x86_64-${{ github.ref_name }}
             rustflags: ""
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64"]' || "macos-12") }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64"]' || 'macos-12') }}
             target: aarch64-apple-darwin
             production_target: target/aarch64-apple-darwin/production
             suffix: macos-aarch64-${{ github.ref_name }}
             rustflags: ""
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || "windows-2022") }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || 'windows-2022') }}
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || "windows-2022") }}
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || 'windows-2022') }}
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-skylake-${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # @v1.1.2
+        uses: arduino/setup-protoc@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-2022"]'), runner.os)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,37 +17,37 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '["self-hosted", "ubuntu-22.04-x86-64", "Linux"]' || '["ubuntu-22.04"]') }}
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '["self-hosted", "ubuntu-22.04-x86-64", "Linux"]' || '["ubuntu-22.04"]') }}
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
             rustflags: "-C target-cpu=skylake"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '["self-hosted", "ubuntu-22.04-x86-64", "Linux"]' || '["ubuntu-22.04"]') }}
+          - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             production_target: target/aarch64-unknown-linux-gnu/aarch64linux
             suffix: ubuntu-aarch64-${{ github.ref_name }}
             rustflags: "-C linker=aarch64-linux-gnu-gcc"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '["self-hosted", "macos-12-arm64", "macOS"]' || '["macos-12"]') }}
+          - os: macos-12
             target: x86_64-apple-darwin
             production_target: target/x86_64-apple-darwin/production
             suffix: macos-x86_64-${{ github.ref_name }}
             rustflags: ""
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '["self-hosted", "macos-12-arm64", "macOS"]' || '["macos-12"]') }}
+          - os: macos-12
             target: aarch64-apple-darwin
             production_target: target/aarch64-apple-darwin/production
             suffix: macos-aarch64-${{ github.ref_name }}
             rustflags: ""
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '["self-hosted", "windows-server-2022-x86-64", "Windows"]' || '["windows-2022"]') }}
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: ${{ fromJson(github.repository_owner == 'subspace' && github.repository == 'subspace/subspace-cli' && '["self-hosted", "windows-server-2022-x86-64", "Windows"]' || '["windows-2022"]') }}
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-skylake-${{ github.ref_name }}
@@ -64,28 +64,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: runner.os == 'Linux' || runner.os == 'macOS'
-
-      - name: Install Protoc Windows
-        run: |
-          Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-win64.zip -Outfile protoc-23.3-win64.zip
-          Expand-Archive -Force .\protoc-23.3-win64.zip -DestinationPath C:\protoc-23.3 
-        if: runner.os == 'Windows'
+          version: "15.0"
+        if: runner.os == 'macOS'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # @v1.1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: runner.os == 'Linux' || runner.os == 'macOS'
 
-      - name: Install Protoc Windows
-        run: |
-          Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/releases/download/v23.3/protoc-23.3-win64.zip -Outfile protoc-23.3-win64.zip
-          Expand-Archive -Force .\protoc-23.3-win64.zip -DestinationPath C:\protoc-23.3 
+      # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
+      - name: Remove msys64
+        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
         if: runner.os == 'Windows'
 
       - name: Linux AArch64 cross-compile packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,37 +17,37 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-20.04
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-20.04"]') }}
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: ubuntu-20.04
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-20.04"]') }}
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
             suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
             rustflags: "-C target-cpu=skylake"
-          - os: ubuntu-20.04
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-20.04"]') }}
             target: aarch64-unknown-linux-gnu
             production_target: target/aarch64-unknown-linux-gnu/aarch64linux
             suffix: ubuntu-aarch64-${{ github.ref_name }}
             rustflags: "-C linker=aarch64-linux-gnu-gcc"
-          - os: macos-12
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64", "macOS"]' || '["macos-12"]') }}
             target: x86_64-apple-darwin
             production_target: target/x86_64-apple-darwin/production
             suffix: macos-x86_64-${{ github.ref_name }}
             rustflags: ""
-          - os: macos-12
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "macos-12-arm64", "macOS"]' || '["macos-12"]') }}
             target: aarch64-apple-darwin
             production_target: target/aarch64-apple-darwin/production
             suffix: macos-aarch64-${{ github.ref_name }}
             rustflags: ""
-          - os: windows-2022
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64", "Windows"]' || '["windows-2022"]') }}
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-v2-${{ github.ref_name }}
             rustflags: "-C target-cpu=x86-64-v2"
-          - os: windows-2022
+          - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64", "Windows"]' || '["windows-2022"]') }}
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
             suffix: windows-x86_64-skylake-${{ github.ref_name }}
@@ -64,22 +64,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # @v3.1.0
 
-      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
+      # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support, we also install clang on Windows
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@8852e4d5c58653ed05135c0a5d949d9c2febcb00 # v1.6.1
         with:
           version: "15.0"
-        if: runner.os == 'macOS'
+        if: contains(fromJSON('["macOS", "macos-12", "Windows", "windows-latest", "windows-2022"]'), runner.os)
 
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # @v1.1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+        if: contains(fromJSON('["Linux", "ubuntu-20.04", "macOS", "macos-12", "windows-2022"]'), runner.os)
 
       # Workaround to resolve link error with C:\msys64\mingw64\bin\libclang.dll
       - name: Remove msys64
         run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
-        if: runner.os == 'Windows'
+        if: contains(fromJSON('["windows-latest", "windows-2022"]'), runner.os)
 
       - name: Linux AArch64 cross-compile packages
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-arm64-cross
@@ -122,7 +123,7 @@ jobs:
           echo "Done!"
         # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
         continue-on-error: ${{ github.github.repository_owner != 'subspace' || github.event_name != 'push' || github.ref_type != 'tag' }}
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' || runner.os == 'macos-12'
 
       - name: Sign Application (Windows)
         uses: skymatic/code-sign-action@cfcc1c15b32938bab6dea25192045b6d2989e4d0 # @v1.1.0
@@ -133,13 +134,13 @@ jobs:
           folder: "${{ matrix.build.production_target }}"
         # Allow code signing to fail on non-release builds and in non-subspace repos (forks)
         continue-on-error: ${{ github.github.repository_owner != 'subspace' || github.event_name != 'push' || github.ref_type != 'tag' }}
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' || runner.os == 'windows-2022'
 
       - name: Prepare executables for uploading (Ubuntu)
         run: |
           mkdir executables
           mv ${{ matrix.build.production_target }}/subspace-cli executables/subspace-cli-${{ matrix.build.suffix }}
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'ubuntu-20.04'
 
       - name: Prepare executables for uploading (macOS)
         run: |
@@ -148,13 +149,13 @@ jobs:
           # Zip it so that signature is not lost
           ditto -c -k --rsrc executables/subspace-cli-${{ matrix.build.suffix }} executables/subspace-cli-${{ matrix.build.suffix }}.zip
           rm executables/subspace-cli-${{ matrix.build.suffix }}
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' || runner.os == 'macos-12'
 
       - name: Prepare executables for uploading (Windows)
         run: |
           mkdir executables
           move ${{ matrix.build.production_target }}/subspace-cli.exe executables/subspace-cli-${{ matrix.build.suffix }}.exe
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' || runner.os == 'windows-2022'
 
       - name: Upload executable to artifacts
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # @v3.1.1

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   rustdoc:
-    runs-on: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-22.04") }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   rustdoc:
-    runs-on: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-22.04"]') }}
+    runs-on: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || "ubuntu-22.04") }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   rustdoc:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64", "Linux"]' || '["ubuntu-22.04"]') }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This PR improves on https://github.com/subspace/subspace-cli/pull/225 and fixes the concerns:

- use cargo stable installed on servers
- removes windows protoc installation for self-hosted runner
- make runners compatible with self-hosted runners and github actions runners
- uses ubuntu-20.04 for backward compatibility with older glibc
