### PR TITLE
Update CLI to use SDK with 3 GB node piece cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7880,7 +7880,7 @@ dependencies = [
 [[package]]
 name = "sdk-dsn"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=2ab653ca34a1799335fd2ba85aadb606a2094250#2ab653ca34a1799335fd2ba85aadb606a2094250"
+source = "git+https://github.com/subspace/subspace-sdk?rev=66d82c1724f280a889821a57d020d8fcd3be5a8c#66d82c1724f280a889821a57d020d8fcd3be5a8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "sdk-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=2ab653ca34a1799335fd2ba85aadb606a2094250#2ab653ca34a1799335fd2ba85aadb606a2094250"
+source = "git+https://github.com/subspace/subspace-sdk?rev=66d82c1724f280a889821a57d020d8fcd3be5a8c#66d82c1724f280a889821a57d020d8fcd3be5a8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7942,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "sdk-node"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=2ab653ca34a1799335fd2ba85aadb606a2094250#2ab653ca34a1799335fd2ba85aadb606a2094250"
+source = "git+https://github.com/subspace/subspace-sdk?rev=66d82c1724f280a889821a57d020d8fcd3be5a8c#66d82c1724f280a889821a57d020d8fcd3be5a8c"
 dependencies = [
  "anyhow",
  "backoff",
@@ -7996,7 +7996,7 @@ dependencies = [
 [[package]]
 name = "sdk-substrate"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=2ab653ca34a1799335fd2ba85aadb606a2094250#2ab653ca34a1799335fd2ba85aadb606a2094250"
+source = "git+https://github.com/subspace/subspace-sdk?rev=66d82c1724f280a889821a57d020d8fcd3be5a8c#66d82c1724f280a889821a57d020d8fcd3be5a8c"
 dependencies = [
  "bytesize",
  "derivative",
@@ -8020,7 +8020,7 @@ dependencies = [
 [[package]]
 name = "sdk-traits"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=2ab653ca34a1799335fd2ba85aadb606a2094250#2ab653ca34a1799335fd2ba85aadb606a2094250"
+source = "git+https://github.com/subspace/subspace-sdk?rev=66d82c1724f280a889821a57d020d8fcd3be5a8c#66d82c1724f280a889821a57d020d8fcd3be5a8c"
 dependencies = [
  "async-trait",
  "parking_lot 0.12.1",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "sdk-utils"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=2ab653ca34a1799335fd2ba85aadb606a2094250#2ab653ca34a1799335fd2ba85aadb606a2094250"
+source = "git+https://github.com/subspace/subspace-sdk?rev=66d82c1724f280a889821a57d020d8fcd3be5a8c#66d82c1724f280a889821a57d020d8fcd3be5a8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9684,7 +9684,7 @@ dependencies = [
 [[package]]
 name = "subspace-sdk"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=2ab653ca34a1799335fd2ba85aadb606a2094250#2ab653ca34a1799335fd2ba85aadb606a2094250"
+source = "git+https://github.com/subspace/subspace-sdk?rev=66d82c1724f280a889821a57d020d8fcd3be5a8c#66d82c1724f280a889821a57d020d8fcd3be5a8c"
 dependencies = [
  "sdk-dsn",
  "sdk-farmer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 whoami = "1"
 zeroize = "1.6.0"
 
-subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "2ab653ca34a1799335fd2ba85aadb606a2094250" }
+subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "66d82c1724f280a889821a57d020d8fcd3be5a8c" }
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subspace-cli"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Description
This PR references a new version of SDK which has 3 GB of node piece cache. Patch version is updated.