### PR TITLE
update cargo.lock to version 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9374,7 +9374,7 @@ dependencies = [
 
 [[package]]
 name = "subspace-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
Cargo.lock did not update to cli version 0.5.3 in last PR.